### PR TITLE
Popup/redirect modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,21 +16,35 @@
  */
 
 import {Activities} from './src/activities';
-import {ActivityIframeHost} from './src/activity-iframe-host';
-import {ActivityIframePort} from './src/activity-iframe-port';
 import {
   ActivityHostDef,
+  ActivityMode,
+  ActivityOpenOptionsDef,
   ActivityPortDef,
+  ActivityRequestDef,
   ActivityResult,
   ActivityResultCode,
 } from './src/activity-types';
+import {ActivityIframeHost} from './src/activity-iframe-host';
+import {ActivityIframePort} from './src/activity-iframe-port';
+import {
+  ActivityWindowPopupHost,
+  ActivityWindowRedirectHost,
+} from './src/activity-window-host';
+import {ActivityWindowPort} from './src/activity-window-port';
 
 module.exports = {
   Activities,
   ActivityHostDef,
   ActivityIframeHost,
   ActivityIframePort,
+  ActivityMode,
+  ActivityOpenOptionsDef,
   ActivityPortDef,
+  ActivityRequestDef,
   ActivityResult,
   ActivityResultCode,
+  ActivityWindowPopupHost,
+  ActivityWindowPort,
+  ActivityWindowRedirectHost,
 };

--- a/main/main.js
+++ b/main/main.js
@@ -29,6 +29,8 @@ const activities = new Activities(self);
 const waitingArray = self[PROP];
 
 const publicObj = {
+  'onResult': activities.onResult.bind(activities),
+  'open': activities.open.bind(activities),
   'openIframe': activities.openIframe.bind(activities),
   'connectHost': activities.connectHost.bind(activities),
 };

--- a/src/activities.js
+++ b/src/activities.js
@@ -15,9 +15,22 @@
  * limitations under the License.
  */
 
-import {ActivityHostDef} from './activity-types';
+import {
+  ActivityHostDef,
+  ActivityOpenOptionsDef,
+  ActivityPortDef,
+  ActivityRequestDef,
+} from './activity-types';
 import {ActivityIframeHost} from './activity-iframe-host';
 import {ActivityIframePort} from './activity-iframe-port';
+import {
+  ActivityWindowPopupHost,
+  ActivityWindowRedirectHost,
+} from './activity-window-host';
+import {
+  ActivityWindowPort,
+  discoverRedirectPort,
+} from './activity-window-port';
 
 
 /**
@@ -32,27 +45,177 @@ export class Activities {
   constructor(win) {
     /** @private @const {!Window} */
     this.win_ = win;
+
+    /** @private @const {string} */
+    this.fragment_ = win.location.hash;
+
+    /**
+     * @private @const {!Object<string, !Array<function(!ActivityPortDef)>>}
+     */
+    this.requestHandlers_ = {};
+
+    /**
+     * The result buffer is indexed by `requestId`.
+     * @private @const {!Object<string, !ActivityPortDef>}
+     */
+    this.resultBuffer_ = {};
   }
 
   /**
    * Start an activity within the specified iframe.
    * @param {!HTMLIFrameElement} iframe
    * @param {string} url
-   * @param {string} origin
    * @param {?Object=} opt_args
    * @return {!Promise<!ActivityIframePort>}
    */
-  openIframe(iframe, url, origin, opt_args) {
-    const port = new ActivityIframePort(iframe, url, origin, opt_args);
+  openIframe(iframe, url, opt_args) {
+    const port = new ActivityIframePort(iframe, url, opt_args);
     return port.connect().then(() => port);
   }
 
   /**
+   * Start an activity in a separate window. The result will be delivered
+   * to the `onResult` callback.
+   *
+   * The activity can be opened in two modes: "popup" and "redirect". This
+   * depends on the `target` value, but also on the browser/environment.
+   *
+   * The allowed `target` values are `_blank`, `_top` and name targets. The
+   * `_self`, `_parent` and similar targets are not allowed.
+   *
+   * The `_top` target indicates that the activity should be opened as a
+   * "redirect", while other targets indicate that the activity should be
+   * opened as a popup. The activity client will try to honor the requested
+   * target. However, it's not always possible. Some environments do not
+   * allow popups and they either force redirect or fail the window open
+   * request. In this case, the activity will try to fallback to the "redirect"
+   * mode.
+   *
+   * @param {string} requestId
+   * @param {string} url
+   * @param {string} target
+   * @param {?Object=} opt_args
+   * @param {?ActivityOpenOptionsDef=} opt_options
+   */
+  open(requestId, url, target, opt_args, opt_options) {
+    const port = new ActivityWindowPort(
+        this.win_, requestId, url, target, opt_args, opt_options);
+    port.open();
+    // Await result if possible. Notice that when falling back to "redirect",
+    // the result will never arrive through this port.
+    port.acceptResult().then(() => {
+      this.consumeResultAll_(requestId, port);
+    });
+  }
+
+  /**
+   * Registers the callback for the result of the activity opened with the
+   * specified `requestId` (see the `open()` method). The callback is a
+   * function that takes a single `ActivityPortDef` argument. The client
+   * can use this object to verify the port using it's origin, verified and
+   * secure channel flags. Then the client can call
+   * `ActivityPortDef.acceptResult()` method to accept the result.
+   *
+   * The activity result is handled via a separate callback because of a
+   * possible redirect. So use of direct callbacks and/or promises is not
+   * possible in that case.
+   *
+   * A typical implementation would look like:
+   * ```
+   * activities.onResult('request1', function(port) {
+   *   // Only verified origins are allowed.
+   *   if (port.getTargetOrigin() == expectedOrigin &&
+   *       port.isTargetOriginVerified() &&
+   *       port.isSecureChannel()) {
+   *     port.acceptResult().then(function(result) {
+   *       handleResultForRequest1(result);
+   *     });
+   *   }
+   * })
+   *
+   * activties.open('request1', request1Url, '_blank');
+   * ```
+   *
+   * @param {string} requestId
+   * @param {function(!ActivityPortDef)} callback
+   */
+  onResult(requestId, callback) {
+    let handlers = this.requestHandlers_[requestId];
+    if (!handlers) {
+      handlers = [];
+      this.requestHandlers_[requestId] = handlers;
+    }
+    handlers.push(callback);
+
+    // Consume available result.
+    const availableResult = this.discoverResult_(requestId);
+    if (availableResult) {
+      this.consumeResult_(availableResult, callback);
+    }
+  }
+
+  /**
    * Start activity implementation handler (host).
+   * @param {(?ActivityRequestDef|?string)=} opt_request
    * @return {!Promise<!ActivityHostDef>}
    */
-  connectHost() {
-    const host = new ActivityIframeHost(this.win_);
-    return host.connect().then(() => host);
+  connectHost(opt_request) {
+    let host;
+    if (this.win_.top != this.win_) {
+      // Iframe host.
+      host = new ActivityIframeHost(this.win_);
+    } else if (this.win_.opener && !this.win_.opener.closed) {
+      // Window host: popup.
+      host = new ActivityWindowPopupHost(this.win_);
+    } else {
+      // Window host: redirect.
+      host = new ActivityWindowRedirectHost(this.win_);
+    }
+    return host.connect(opt_request);
+  }
+
+  /**
+   * @param {string} requestId
+   * @return {?ActivityPortDef}
+   * @private
+   */
+  discoverResult_(requestId) {
+    let port = this.resultBuffer_[requestId];
+    if (!port && this.fragment_) {
+      port = discoverRedirectPort(
+          this.win_, this.fragment_, requestId);
+      if (port) {
+        this.resultBuffer_[requestId] = port;
+      }
+    }
+    return port;
+  }
+
+  /**
+   * @param {!ActivityPortDef} port
+   * @param {function(!ActivityPortDef)} callback
+   * @private
+   */
+  consumeResult_(port, callback) {
+    Promise.resolve().then(() => {
+      callback(port);
+    });
+  }
+
+  /**
+   * @param {string} requestId
+   * @param {!ActivityPortDef} port
+   * @private
+   */
+  consumeResultAll_(requestId, port) {
+    // Find and execute handlers.
+    const handlers = this.requestHandlers_[requestId];
+    if (handlers) {
+      handlers.forEach(handler => {
+        this.consumeResult_(port, handler);
+      });
+    }
+    // Buffer the result for callbacks that may arrive in the future.
+    this.resultBuffer_[requestId] = port;
   }
 }

--- a/src/activities.js
+++ b/src/activities.js
@@ -100,10 +100,9 @@ export class Activities {
   open(requestId, url, target, opt_args, opt_options) {
     const port = new ActivityWindowPort(
         this.win_, requestId, url, target, opt_args, opt_options);
-    port.open();
-    // Await result if possible. Notice that when falling back to "redirect",
-    // the result will never arrive through this port.
-    port.acceptResult().then(() => {
+    port.open().then(() => {
+      // Await result if possible. Notice that when falling back to "redirect",
+      // the result will never arrive through this port.
       this.consumeResultAll_(requestId, port);
     });
   }

--- a/src/activity-window-host.js
+++ b/src/activity-window-host.js
@@ -1,0 +1,501 @@
+/**
+ * @license
+ * Copyright 2017 The Web Activities Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActivityHostDef,
+  ActivityMode,
+  ActivityRequestDef,
+  ActivityResultCode,
+} from './activity-types';
+import {Messenger} from './messenger';
+import {
+  getOriginFromUrl,
+  getQueryParam,
+  getWindowOrigin,
+  parseRequest,
+  serializeRequest,
+} from './utils';
+
+
+/**
+ * The `ActivityHostDef` implementation for the standalone window activity
+ * executed as a popup. The communication is done via a secure messaging
+ * channel with a client. However, if messaging channel cannot be established,
+ * this type of host delegates to the redirect host.
+ *
+ * @implements {ActivityHostDef}
+ */
+export class ActivityWindowPopupHost {
+
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    if (!win.opener || win.opener == win) {
+      throw new Error('No window.opener');
+    }
+
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private {!Window} */
+    this.target_ = win.opener;
+
+    /** @private @const {!Messenger} */
+    this.messenger_ = new Messenger(
+        this.win_,
+        this.target_,
+        /* targetOrigin */ null);
+
+    /** @private {?Object} */
+    this.args_ = null;
+
+    /** @private {boolean} */
+    this.connected_ = false;
+
+    /** @private {?function(!ActivityHostDef)} */
+    this.connectedResolver_ = null;
+
+    /** @private @const {!Promise<!ActivityHostDef>} */
+    this.connectedPromise_ = new Promise(resolve => {
+      this.connectedResolver_ = resolve;
+    });
+
+    /** @private {boolean} */
+    this.accepted_ = false;
+
+    /** @private {?function(number, number, boolean)} */
+    this.onResizeComplete_ = null;
+
+    /** @private {?Element} */
+    this.sizeContainer_ = null;
+
+    /** @private @const {!ActivityWindowRedirectHost} */
+    this.redirectHost_ = new ActivityWindowRedirectHost(this.win_);
+  }
+
+  /**
+   * Connects the activity to the client.
+   * @param {(?ActivityRequestDef|?string)=} opt_request
+   * @return {!Promise<!ActivityHostDef>}
+   */
+  connect(opt_request) {
+    this.connected_ = false;
+    this.accepted_ = false;
+    return this.redirectHost_.connect(opt_request).then(() => {
+      this.messenger_.connect(this.handleCommand_.bind(this));
+      this.messenger_.sendCommand('connect');
+      // Give the popup channel ~5 seconds to connect and if it can't,
+      // assume that the client is offloaded and proceed with redirect.
+      setTimeout(() => {
+        if (this.connectedResolver_) {
+          this.connectedResolver_(this.redirectHost_);
+          this.connectedResolver_ = null;
+        }
+      }, 5000);
+      return this.connectedPromise_;
+    });
+  }
+
+  /** @override */
+  disconnect() {
+    this.connected_ = false;
+    this.accepted_ = false;
+    this.messenger_.disconnect();
+
+    // Try to close the window. A similar attempt will be made by the client
+    // port.
+    try {
+      this.win_.close();
+    } catch (e) {
+      // Ignore.
+    }
+    // TODO(dvoytenko): consider an optional "failed to close" callback. Wait
+    // for ~5s and check `this.win_.closed`.
+  }
+
+  /** @override */
+  getRequestString() {
+    this.ensureConnected_();
+    return this.redirectHost_.getRequestString();
+  }
+
+  /** @override */
+  getMode() {
+    return ActivityMode.POPUP;
+  }
+
+  /** @override */
+  getTargetOrigin() {
+    this.ensureConnected_();
+    return this.messenger_.getTargetOrigin();
+  }
+
+  /** @override */
+  isTargetOriginVerified() {
+    this.ensureConnected_();
+    // The origin is always verified via messaging.
+    return true;
+  }
+
+  /** @override */
+  isSecureChannel() {
+    return true;
+  }
+
+  /** @override */
+  accept() {
+    this.ensureConnected_();
+    this.accepted_ = true;
+  }
+
+  /** @override */
+  getArgs() {
+    this.ensureConnected_();
+    return this.args_;
+  }
+
+  /** @override */
+  ready() {
+    this.ensureAccepted_();
+    this.messenger_.sendCommand('ready');
+  }
+
+  /** @override */
+  setSizeContainer(element) {
+    this.sizeContainer_ = element;
+  }
+
+  /** @override */
+  onResizeComplete(callback) {
+    this.onResizeComplete_ = callback;
+  }
+
+  /** @override */
+  resized() {
+    setTimeout(() => this.resized_(), 50);
+  }
+
+  /** @override */
+  result(data) {
+    this.sendResult_(ActivityResultCode.OK, data);
+  }
+
+  /** @override */
+  cancel() {
+    this.sendResult_(ActivityResultCode.CANCELED, /* data */ null);
+  }
+
+  /** @override */
+  failed(reason) {
+    this.sendResult_(ActivityResultCode.FAILED, String(reason));
+  }
+
+  /** @private */
+  ensureConnected_() {
+    if (!this.connected_) {
+      throw new Error('not connected');
+    }
+  }
+
+  /** @private */
+  ensureAccepted_() {
+    if (!this.accepted_) {
+      throw new Error('not accepted');
+    }
+  }
+
+  /**
+   * @param {!ActivityResultCode} code
+   * @param {*} data
+   * @private
+   */
+  sendResult_(code, data) {
+    this.ensureAccepted_();
+    this.messenger_.sendCommand('result', {
+      'code': code,
+      'data': data,
+    });
+    // Do not disconnect, wait for "close" message to ack the result receipt.
+    // TODO(dvoytenko): Consider taking an action if result acknowledgement
+    // does not arrive in some time (3-5s). For instance, we can redirect
+    // back or ask the host implementer to take an action.
+  }
+
+  /**
+   * @param {string} cmd
+   * @param {?Object} payload
+   * @private
+   */
+  handleCommand_(cmd, payload) {
+    if (cmd == 'start') {
+      // Response to "connect" command.
+      this.args_ = payload;
+      this.connected_ = true;
+      this.connectedResolver_(this);
+    } else if (cmd == 'close') {
+      this.disconnect();
+    }
+  }
+
+  /** @private */
+  resized_() {
+    if (this.sizeContainer_) {
+      const requestedHeight = this.sizeContainer_.scrollHeight;
+      const allowedHeight = this.win_./*OK*/innerHeight;
+      if (this.onResizeComplete_) {
+        this.onResizeComplete_(
+            allowedHeight,
+            requestedHeight,
+            allowedHeight < requestedHeight);
+      }
+    }
+  }
+}
+
+
+/**
+ * The `ActivityHostDef` implementation for the standalone window activity
+ * executed via redirect. The channel is not secure since the parameters
+ * and the results are passed around in the redirect URL and thus can be
+ * exploited or consumed by a 3rd-party.
+ *
+ * @implements {ActivityHostDef}
+ */
+export class ActivityWindowRedirectHost {
+
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private {?string} */
+    this.requestId_ = null;
+
+    /** @private {?string} */
+    this.returnUrl_ = null;
+
+    /** @private {?string} */
+    this.targetOrigin_ = null;
+
+    /** @private {boolean} */
+    this.targetOriginVerified_ = false;
+
+    /** @private {?Object} */
+    this.args_ = null;
+
+    /** @private {boolean} */
+    this.connected_ = false;
+
+    /** @private {boolean} */
+    this.accepted_ = false;
+
+    /** @private {?function(number, number, boolean)} */
+    this.onResizeComplete_ = null;
+
+    /** @private {?Element} */
+    this.sizeContainer_ = null;
+  }
+
+  /**
+   * Connects the activity to the client.
+   * @param {(?ActivityRequestDef|?string)=} opt_request
+   * @return {!Promise}
+   */
+  connect(opt_request) {
+    return Promise.resolve().then(() => {
+      this.connected_ = false;
+      this.accepted_ = false;
+      let request;
+      if (typeof opt_request == 'object') {
+        request = opt_request;
+      } else {
+        let requestString;
+        if (opt_request && typeof opt_request == 'string') {
+          requestString = opt_request;
+        } else {
+          const fragmentRequestParam =
+              getQueryParam(this.win_.location.hash, '__WA__');
+          if (fragmentRequestParam) {
+            requestString = decodeURIComponent(fragmentRequestParam);
+          }
+        }
+        if (requestString) {
+          request = parseRequest(requestString);
+        }
+      }
+      if (!request || !request.requestId || !request.returnUrl) {
+        throw new Error('Request must have requestId and returnUrl');
+      }
+      this.requestId_ = request.requestId;
+      this.args_ = request.args;
+      this.returnUrl_ = request.returnUrl;
+      this.targetOrigin_ = getOriginFromUrl(request.returnUrl);
+      // TODO(dvoytenko): Use `document.referrer` to verify origin.
+      this.targetOriginVerified_ = false;
+      this.connected_ = true;
+      return this;
+    });
+  }
+
+  /** @override */
+  disconnect() {
+    this.connected_ = false;
+    this.accepted_ = false;
+  }
+
+  /** @override */
+  getRequestString() {
+    this.ensureConnected_();
+    return serializeRequest({
+      requestId: /** @type {string} */ (this.requestId_),
+      returnUrl: /** @type {string} */ (this.returnUrl_),
+      args: this.args_,
+    });
+  }
+
+  /** @override */
+  getMode() {
+    return ActivityMode.REDIRECT;
+  }
+
+  /** @override */
+  getTargetOrigin() {
+    this.ensureConnected_();
+    return /** @type {string} */ (this.targetOrigin_);
+  }
+
+  /** @override */
+  isTargetOriginVerified() {
+    this.ensureConnected_();
+    return this.targetOriginVerified_;
+  }
+
+  /** @override */
+  isSecureChannel() {
+    return false;
+  }
+
+  /** @override */
+  accept() {
+    this.ensureConnected_();
+    this.accepted_ = true;
+  }
+
+  /** @override */
+  getArgs() {
+    this.ensureConnected_();
+    return this.args_;
+  }
+
+  /** @override */
+  ready() {
+    this.ensureAccepted_();
+  }
+
+  /** @override */
+  setSizeContainer(element) {
+    this.sizeContainer_ = element;
+  }
+
+  /** @override */
+  onResizeComplete(callback) {
+    this.onResizeComplete_ = callback;
+  }
+
+  /** @override */
+  resized() {
+    setTimeout(() => this.resized_(), 50);
+  }
+
+  /** @override */
+  result(data) {
+    this.sendResult_(ActivityResultCode.OK, data);
+  }
+
+  /** @override */
+  cancel() {
+    this.sendResult_(ActivityResultCode.CANCELED, /* data */ null);
+  }
+
+  /** @override */
+  failed(reason) {
+    this.sendResult_(ActivityResultCode.FAILED, String(reason));
+  }
+
+  /** @private */
+  ensureConnected_() {
+    if (!this.connected_) {
+      throw new Error('not connected');
+    }
+  }
+
+  /** @private */
+  ensureAccepted_() {
+    if (!this.accepted_) {
+      throw new Error('not accepted');
+    }
+  }
+
+  /**
+   * @param {!ActivityResultCode} code
+   * @param {*} data
+   * @private
+   */
+  sendResult_(code, data) {
+    this.ensureAccepted_();
+    const response = {
+      'requestId': this.requestId_,
+      'origin': getWindowOrigin(this.win_),
+      'code': code,
+      'data': data,
+    };
+    const returnUrl =
+        this.returnUrl_ +
+        (this.returnUrl_.indexOf('#') == -1 ? '#' : '&') +
+        '__WA_RES__=' + encodeURIComponent(JSON.stringify(response));
+    this.redirect_(returnUrl);
+  }
+
+  /**
+   * @param {string} returnUrl
+   * @private
+   */
+  redirect_(returnUrl) {
+    if (this.win_.location.replace) {
+      this.win_.location.replace(returnUrl);
+    } else {
+      this.win_.location.assign(returnUrl);
+    }
+  }
+
+  /** @private */
+  resized_() {
+    if (this.sizeContainer_) {
+      const requestedHeight = this.sizeContainer_.scrollHeight;
+      const allowedHeight = this.win_./*OK*/innerHeight;
+      if (this.onResizeComplete_) {
+        this.onResizeComplete_(
+            allowedHeight,
+            requestedHeight,
+            allowedHeight < requestedHeight);
+      }
+    }
+  }
+}

--- a/src/activity-window-port.js
+++ b/src/activity-window-port.js
@@ -1,0 +1,429 @@
+/**
+ * @license
+ * Copyright 2017 The Web Activities Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActivityMode,
+  ActivityOpenOptionsDef,
+  ActivityPortDef,
+  ActivityResult,
+  ActivityResultCode,
+} from './activity-types';
+import {Messenger} from './messenger';
+import {
+  getQueryParam,
+  removeFragment,
+  removeQueryParam,
+  serializeRequest,
+} from './utils';
+
+
+/**
+ * The `ActivityPort` implementation for the standalone window acitivity
+ * client executed as a popup.
+ *
+ * @implements {ActivityPortDef}
+ */
+export class ActivityWindowPort {
+
+  /**
+   * @param {!Window} win
+   * @param {string} requestId
+   * @param {string} url
+   * @param {string} target
+   * @param {?Object=} opt_args
+   * @param {?ActivityOpenOptionsDef=} opt_options
+   */
+  constructor(win, requestId, url, target, opt_args, opt_options) {
+    const isValidTarget =
+        target &&
+        (target == '_blank' || target == '_top' || target[0] != '_');
+    if (!isValidTarget) {
+      throw new Error('The only allowed targets are "_blank", "_top"' +
+          ' and name targets');
+    }
+
+    /** @private @const {!Window} */
+    this.win_ = win;
+    /** @private @const {string} */
+    this.requestId_ = requestId;
+    /** @private @const {string} */
+    this.url_ = url;
+    /** @private @const {string} */
+    this.openTarget_ = target;
+    /** @private @const {?Object} */
+    this.args_ = opt_args || null;
+    /** @private @const {?ActivityOpenOptionsDef} */
+    this.options_ = opt_options || null;
+
+    /** @private {?function(!ActivityResult)} */
+    this.resultResolver_ = null;
+
+    /** @private {?function(!Error)} */
+    this.resultReject_ = null;
+
+    /** @private @const {!Promise<!ActivityResult>} */
+    this.resultPromise_ = new Promise((resolve, reject) => {
+      this.resultResolver_ = resolve;
+      this.resultReject_ = reject;
+    });
+
+    /** @private {?Window} */
+    this.targetWin_ = null;
+
+    /** @private {?number} */
+    this.heartbeatInterval_ = null;
+
+    /** @private {?Messenger} */
+    this.messenger_ = null;
+  }
+
+  /** @override */
+  getMode() {
+    return this.openTarget_ == '_top' ?
+        ActivityMode.REDIRECT :
+        ActivityMode.POPUP;
+  }
+
+  /**
+   * Opens the window.
+   */
+  open() {
+    this.openInternal_();
+  }
+
+  /**
+   * Disconnect the activity binding and cleanup listeners.
+   */
+  disconnect() {
+    if (this.heartbeatInterval_) {
+      this.win_.clearInterval(this.heartbeatInterval_);
+      this.heartbeatInterval_ = null;
+    }
+    if (this.messenger_) {
+      this.messenger_.disconnect();
+      this.messenger_ = null;
+    }
+    if (this.targetWin_) {
+      // Try to close the popup window. The host will also try to do the same.
+      try {
+        this.targetWin_.close();
+      } catch (e) {
+        // Ignore.
+      }
+      this.targetWin_ = null;
+    }
+    this.resultResolver_ = null;
+    this.resultReject_ = null;
+  }
+
+  /** @override */
+  getTargetOrigin() {
+    return this.messenger_.getTargetOrigin();
+  }
+
+  /** @override */
+  isTargetOriginVerified() {
+    return true;
+  }
+
+  /** @override */
+  isSecureChannel() {
+    return true;
+  }
+
+  /** @override */
+  acceptResult() {
+    return this.resultPromise_;
+  }
+
+  /**
+   * This method wraps around window's open method. It first tries to execute
+   * `open` call with the provided target and if it fails, it retries the call
+   * with the `_top` target. This is necessary given that in some embedding
+   * scenarios, such as iOS' WKWebView, navigation to `_blank` and other targets
+   * is blocked by default.
+   * @private
+   */
+  openInternal_() {
+    const featuresStr = this.buildFeatures_();
+
+    // Defensively, the URL in all cases will contain the request payload.
+    const returnUrl =
+        this.options_ && this.options_.returnUrl ||
+        removeFragment(this.win_.location.href);
+    const requestString = serializeRequest({
+      requestId: this.requestId_,
+      returnUrl,
+      args: this.args_,
+    });
+    const url =
+        this.url_ +
+        (this.url_.indexOf('#') == -1 ? '#' : '&') +
+        '__WA__=' + encodeURIComponent(requestString);
+
+    // Open the window.
+    // Try first with the specified target. If we're inside the WKWebView or
+    // a similar environments, this method is expected to fail by default for
+    // all targets except `_top`.
+    let targetWin;
+    let openTarget = this.openTarget_;
+    try {
+      targetWin = this.win_.open(url, openTarget, featuresStr);
+    } catch (e) {
+      // Ignore.
+    }
+    // Then try with `_top` target.
+    if (!targetWin && openTarget != '_top') {
+      openTarget = '_top';
+      try {
+        targetWin = this.win_.open(url, openTarget);
+      } catch (e) {
+        // Ignore.
+      }
+    }
+
+    // Setup the target window.
+    if (targetWin) {
+      this.targetWin_ = targetWin;
+      if (openTarget != '_top') {
+        this.setupPopup_();
+      }
+    } else {
+      this.disconnectWithError_(new Error('failed to open window'));
+    }
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  buildFeatures_() {
+    const screen = this.win_.screen;
+    let w = Math.floor(Math.min(600, screen.width * 0.9));
+    let h = Math.floor(Math.min(600, screen.height * 0.9));
+    if (this.options_) {
+      if (this.options_.width) {
+        w = Math.min(this.options_.width, screen.width);
+      }
+      if (this.options_.height) {
+        h = Math.min(this.options_.height, screen.height);
+      }
+    }
+    const x = Math.floor((screen.width - w) / 2);
+    const y = Math.floor((screen.height - h) / 2);
+    const features = {
+      'height': h,
+      'width': w,
+      'left': x,
+      'top': y,
+      'resizable': 'yes',
+      'scrollbars': 'yes',
+    };
+    let featuresStr = '';
+    for (const f in features) {
+      if (featuresStr) {
+        featuresStr += ',';
+      }
+      featuresStr += `${f}=${features[f]}`;
+    }
+    return featuresStr;
+  }
+
+  /** @private */
+  setupPopup_() {
+    // Keep alive to catch the window closing, which would indicate
+    // "cancel" signal.
+    this.heartbeatInterval_ = this.win_.setInterval(() => {
+      if (!this.targetWin_ || this.targetWin_.closed) {
+        this.win_.clearInterval(this.heartbeatInterval_);
+        this.heartbeatInterval_ = null;
+        // Give a chance for the result to arrive, but otherwise consider the
+        // responce to be empty.
+        this.win_.setTimeout(() => {
+          try {
+            this.result_(ActivityResultCode.CANCELED, /* data */ null);
+          } catch (e) {
+            this.disconnectWithError_(e);
+          }
+        }, 3000);
+      }
+    }, 500);
+
+    // Start up messaging. The messaging is explicitly allowed to proceed
+    // without origin check b/c all arguments have already been passed in
+    // the URL and special handling is enforced when result is delivered.
+    this.messenger_ = new Messenger(
+        this.win_,
+        /** @type {!Window} */ (this.targetWin_),
+        /* targetOrigin */ null);
+    this.messenger_.connect(this.handleCommand_.bind(this));
+  }
+
+  /**
+   * @param {!Error} reason
+   * @private
+   */
+  disconnectWithError_(reason) {
+    if (this.resultReject_) {
+      this.resultReject_(reason);
+    }
+    this.disconnect();
+  }
+
+  /**
+   * @param {!ActivityResultCode} code
+   * @param {*} data
+   * @private
+   */
+  result_(code, data) {
+    if (this.resultResolver_) {
+      this.resultResolver_(new ActivityResult(
+          code,
+          data,
+          this.getTargetOrigin(),
+          this.isTargetOriginVerified(),
+          this.isSecureChannel()));
+      this.resultResolver_ = null;
+      this.resultReject_ = null;
+    }
+    if (this.messenger_) {
+      this.messenger_.sendCommand('close');
+    }
+    this.disconnect();
+  }
+
+  /**
+   * @param {string} cmd
+   * @param {?Object} payload
+   * @private
+   */
+  handleCommand_(cmd, payload) {
+    if (cmd == 'connect') {
+      // First ever message. Indicates that the receiver is listening.
+      this.messenger_.sendCommand('start', this.args_);
+    } else if (cmd == 'result') {
+      // The last message. Indicates that the result has been received.
+      const code = /** @type {!ActivityResultCode} */ (payload['code']);
+      const data =
+          code == ActivityResultCode.FAILED ?
+          new Error(payload['data'] || '') :
+          payload['data'];
+      this.result_(code, data);
+    }
+  }
+}
+
+
+/**
+ * @param {!Window} win
+ * @param {string} fragment
+ * @param {string} requestId
+ * @return {?ActivityPortDef}
+ */
+export function discoverRedirectPort(win, fragment, requestId) {
+  // Try to find the result in the fragment.
+  const paramName = '__WA_RES__';
+  const fragmentParam = getQueryParam(fragment, paramName);
+  if (!fragmentParam) {
+    return null;
+  }
+  const response = /** @type {?Object} */ (JSON.parse(
+      decodeURIComponent(fragmentParam)));
+  if (!response || response['requestId'] != requestId) {
+    return null;
+  }
+
+  // Remove the found param from the fragment.
+  const cleanFragment = removeQueryParam(win.location.hash, paramName) || '';
+  if (cleanFragment != win.location.hash) {
+    if (win.history && win.history.replaceState) {
+      try {
+        win.history.replaceState(win.history.state, '', cleanFragment);
+      } catch (e) {
+        // Ignore.
+      }
+    }
+  }
+
+  // TODO(dvoytenko): Use `document.referrer` to verify origin.
+  const code = response['code'];
+  const data = response['data'];
+  const origin = response['origin'];
+  const originVerified = false;
+  return new ActivityWindowRedirectPort(
+      code,
+      data,
+      origin,
+      originVerified);
+}
+
+
+/**
+ * The `ActivityPort` implementation for the standalone window acitivity
+ * client executed as a popup.
+ *
+ * @implements {ActivityPortDef}
+ */
+class ActivityWindowRedirectPort {
+
+  /**
+   * @param {!ActivityResultCode} code
+   * @param {*} data
+   * @param {string} targetOrigin
+   * @param {boolean} targetOriginVerified
+   */
+  constructor(code, data, targetOrigin, targetOriginVerified) {
+    /** @private @const {!ActivityResultCode} */
+    this.code_ = code;
+    /** @private @const {*} */
+    this.data_ = data;
+    /** @private {string} */
+    this.targetOrigin_ = targetOrigin;
+    /** @private {boolean} */
+    this.targetOriginVerified_ = targetOriginVerified;
+  }
+
+  /** @override */
+  getMode() {
+    return ActivityMode.REDIRECT;
+  }
+
+  /** @override */
+  getTargetOrigin() {
+    return this.targetOrigin_;
+  }
+
+  /** @override */
+  isTargetOriginVerified() {
+    return this.targetOriginVerified_;
+  }
+
+  /** @override */
+  isSecureChannel() {
+    return false;
+  }
+
+  /** @override */
+  acceptResult() {
+    return Promise.resolve(new ActivityResult(
+        this.code_,
+        this.data_,
+        this.targetOrigin_,
+        this.targetOriginVerified_,
+        this.isSecureChannel()));
+  }
+}

--- a/src/activity-window-port.js
+++ b/src/activity-window-port.js
@@ -99,10 +99,15 @@ export class ActivityWindowPort {
   }
 
   /**
-   * Opens the window.
+   * Opens the activity in a window, either as a popup or via redirect.
+   *
+   * Returns the promise that will yield when the window returns or closed.
+   * Notice, that this promise may never complete if "redirect" mode was used.
+   *
+   * @return {!Promise}
    */
   open() {
-    this.openInternal_();
+    return this.openInternal_();
   }
 
   /**
@@ -156,6 +161,7 @@ export class ActivityWindowPort {
    * with the `_top` target. This is necessary given that in some embedding
    * scenarios, such as iOS' WKWebView, navigation to `_blank` and other targets
    * is blocked by default.
+   * @return {!Promise}
    * @private
    */
   openInternal_() {
@@ -205,6 +211,11 @@ export class ActivityWindowPort {
     } else {
       this.disconnectWithError_(new Error('failed to open window'));
     }
+
+    // Return result promise, even though it may never complete.
+    return this.resultPromise_.catch(() => {
+      // Ignore. Call to the `acceptResult()` should fail if needed.
+    });
   }
 
   /**

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -78,15 +78,24 @@ export class Messenger {
    * @return {!Window}
    */
   getTarget() {
+    const target = this.getOptionalTarget_();
+    if (!target) {
+      throw new Error('not connected');
+    }
+    return target;
+  }
+
+  /**
+   * @return {?Window}
+   * @private
+   */
+  getOptionalTarget_() {
     if (this.onCommand_ && !this.target_) {
       if (typeof this.targetOrCallback_ == 'function') {
         this.target_ = this.targetOrCallback_();
       } else {
         this.target_ = /** @type {!Window} */ (this.targetOrCallback_);
       }
-    }
-    if (!this.target_) {
-      throw new Error('not connected');
     }
     return this.target_;
   }
@@ -136,6 +145,11 @@ export class Messenger {
     const payload = data['payload'] || null;
     if (this.targetOrigin_ == null && cmd == 'start') {
       this.targetOrigin_ = origin;
+    }
+    if (this.targetOrigin_ == null && event.source) {
+      if (this.getOptionalTarget_() == event.source) {
+        this.targetOrigin_ = origin;
+      }
     }
     // Notice that event.source may differ from the target because of
     // friendly-iframe intermediaries.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2017 The Web Activities Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActivityRequestDef} from './activity-types';
+
+let aResolver;
+
+
+/**
+ * @param {string} urlString
+ * @return {!URL}
+ */
+function parseUrl(urlString) {
+  if (!aResolver) {
+    aResolver = document.createElement('a');
+  }
+  aResolver.href = urlString;
+  return /** @type {!URL} */ (aResolver);
+}
+
+
+/**
+ * @param {!Location|!URL} loc
+ * @return {string}
+ */
+function getOrigin(loc) {
+  return loc.origin || loc.protocol + '//' + loc.host;
+}
+
+
+/**
+ * @param {string} urlString
+ * @return {string}
+ */
+export function getOriginFromUrl(urlString) {
+  return getOrigin(parseUrl(urlString));
+}
+
+
+/**
+ * @param {!Window} win
+ * @return {string}
+ */
+export function getWindowOrigin(win) {
+  return (win.origin || getOrigin(win.location));
+}
+
+
+/**
+ * @param {string} urlString
+ * @return {string}
+ */
+export function removeFragment(urlString) {
+  const index = urlString.indexOf('#');
+  if (index == -1) {
+    return urlString;
+  }
+  return urlString.substring(0, index);
+}
+
+
+/**
+ * Parses and builds Object of URL query string.
+ * @param {string} query The URL query string.
+ * @return {!Object<string, string>}
+ */
+function parseQueryString(query) {
+  if (!query) {
+    return {};
+  }
+  return (/^[?#]/.test(query) ? query.slice(1) : query)
+      .split('&')
+      .reduce((params, param) => {
+        const item = param.split('=');
+        const key = decodeURIComponent(item[0] || '');
+        const value = decodeURIComponent(item[1] || '');
+        if (key) {
+          params[key] = value;
+        }
+        return params;
+      }, {});
+}
+
+
+/**
+ * @param {string} queryString
+ * @return {?string}
+ */
+export function getQueryParam(queryString, param) {
+  return parseQueryString(queryString)[param];
+}
+
+
+/**
+ * @param {string} queryString
+ * @return {?string}
+ */
+export function removeQueryParam(queryString, param) {
+  if (!queryString) {
+    return queryString;
+  }
+  const search = encodeURIComponent(param) + '=';
+  let index = -1;
+  do {
+    index = queryString.indexOf(search, index);
+    if (index != -1) {
+      const prev = index > 0 ? queryString.substring(index - 1, index) : '';
+      if (prev == '' || prev == '?' || prev == '#' || prev == '&') {
+        let end = queryString.indexOf('&', index + 1);
+        if (end == -1) {
+          end = queryString.length;
+        }
+        queryString =
+            queryString.substring(0, index) +
+            queryString.substring(end + 1);
+      } else {
+        index++;
+      }
+    }
+  } while (index != -1 && index < queryString.length);
+  return queryString;
+}
+
+
+/**
+ * @param {?string} requestString
+ * @return {?ActivityRequestDef}
+ */
+export function parseRequest(requestString) {
+  if (!requestString) {
+    return null;
+  }
+  const parsed = /** @type {!Object} */ (JSON.parse(requestString));
+  return {
+    requestId: /** @type {string} */ (parsed['requestId']),
+    returnUrl: /** @type {string} */ (parsed['returnUrl']),
+    args: /** @type {?Object} */ (parsed['args'] || null),
+  };
+}
+
+
+/**
+ * @param {!ActivityRequestDef} request
+ * @return {string}
+ */
+export function serializeRequest(request) {
+  return JSON.stringify({
+    'requestId': request.requestId,
+    'returnUrl': request.returnUrl,
+    'args': request.args,
+  });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,24 +17,25 @@
 
 import {ActivityRequestDef} from './activity-types';
 
+/** @type {?HTMLAnchorElement} */
 let aResolver;
 
 
 /**
  * @param {string} urlString
- * @return {!URL}
+ * @return {!HTMLAnchorElement}
  */
 function parseUrl(urlString) {
   if (!aResolver) {
-    aResolver = document.createElement('a');
+    aResolver = /** @type {!HTMLAnchorElement} */ (document.createElement('a'));
   }
   aResolver.href = urlString;
-  return /** @type {!URL} */ (aResolver);
+  return /** @type {!HTMLAnchorElement} */ (aResolver);
 }
 
 
 /**
- * @param {!Location|!URL} loc
+ * @param {!Location|!URL|!HTMLAnchorElement} loc
  * @return {string}
  */
 function getOrigin(loc) {
@@ -97,7 +98,8 @@ function parseQueryString(query) {
 
 
 /**
- * @param {string} queryString
+ * @param {string} queryString  A query string in the form of "a=b&c=d". Could
+ *   be optionally prefixed with "?" or "#".
  * @return {?string}
  */
 export function getQueryParam(queryString, param) {
@@ -106,7 +108,8 @@ export function getQueryParam(queryString, param) {
 
 
 /**
- * @param {string} queryString
+ * @param {string} queryString  A query string in the form of "a=b&c=d". Could
+ *   be optionally prefixed with "?" or "#".
  * @return {?string}
  */
 export function removeQueryParam(queryString, param) {

--- a/test/fixtures/activity-iframe-host.html
+++ b/test/fixtures/activity-iframe-host.html
@@ -14,6 +14,8 @@
 
 (window.ACTIVITIES = window.ACTIVITIES || []).push(function(activities) {
   activities.connectHost().then(function(host) {
+    host.accept();
+
     var container = document.getElementById('container');
     host.setSizeContainer(container);
 

--- a/test/functional/activities-test.js
+++ b/test/functional/activities-test.js
@@ -18,6 +18,12 @@
 import {Activities} from '../../src/activities';
 import {ActivityIframePort} from '../../src/activity-iframe-port';
 import {ActivityIframeHost} from '../../src/activity-iframe-host';
+import {ActivityResult, ActivityResultCode} from '../../src/activity-types';
+import {ActivityWindowPort} from '../../src/activity-window-port';
+import {
+  ActivityWindowPopupHost,
+  ActivityWindowRedirectHost,
+} from '../../src/activity-window-host';
 
 
 describes.realWin('Activities', {}, env => {
@@ -50,14 +56,14 @@ describes.realWin('Activities', {}, env => {
     it('should open an iframe and connect', () => {
       const promise = activities.openIframe(
           iframe,
-          '/iframe',
-          'https://example.com',
+          'https://example.com/iframe',
           {a: 1});
       connectResolve();
       return promise.then(port => {
         expect(port).to.be.instanceof(ActivityIframePort);
         expect(port.iframe_).to.equal(iframe);
-        expect(port.url_).to.equal('/iframe');
+        expect(port.url_).to.equal('https://example.com/iframe');
+        expect(port.targetOrigin_).to.equal('https://example.com');
         expect(port.args_).to.deep.equal({a: 1});
       });
     });
@@ -65,13 +71,13 @@ describes.realWin('Activities', {}, env => {
     it('should open an iframe with no args', () => {
       const promise = activities.openIframe(
           iframe,
-          '/iframe',
-          'https://example.com');
+          'https://example.com/iframe');
       connectResolve();
       return promise.then(port => {
         expect(port).to.be.instanceof(ActivityIframePort);
         expect(port.iframe_).to.equal(iframe);
-        expect(port.url_).to.equal('/iframe');
+        expect(port.url_).to.equal('https://example.com/iframe');
+        expect(port.targetOrigin_).to.equal('https://example.com');
         expect(port.args_).to.be.null;
       });
     });
@@ -79,16 +85,203 @@ describes.realWin('Activities', {}, env => {
     it('should fail opening an iframe if connect fails', () => {
       const promise = activities.openIframe(
           iframe,
-          '/iframe',
-          'https://example.com',
+          'https://example.com/iframe',
           {a: 1});
       connectReject(new Error('intentional'));
       return expect(promise).to.eventually.be.rejectedWith('intentional');
     });
   });
 
+  describe('open/onResult', () => {
+    let openStub;
+    let port;
+    let resultPromise, resultResolver;
+    let acceptResultStub;
+
+    beforeEach(() => {
+      port = null;
+      openStub = sandbox.stub(ActivityWindowPort.prototype, 'open',
+          function() {
+            port = this;
+          });
+      resultPromise = new Promise(resolve => {
+        resultResolver = resolve;
+      });
+      acceptResultStub = sandbox.stub(
+          ActivityWindowPort.prototype,
+          'acceptResult',
+          () => resultPromise);
+    });
+
+    it('should open window', () => {
+      activities.open(
+          'request1',
+          'https://example.com/file',
+          '_blank',
+          {a: 1},
+          {width: 300});
+      expect(openStub).to.be.calledOnce;
+      expect(acceptResultStub).to.be.calledOnce;
+      expect(port).to.exist;
+      expect(port).to.be.instanceof(ActivityWindowPort);
+      expect(port.requestId_).to.equal('request1');
+      expect(port.url_).to.equal('https://example.com/file');
+      expect(port.openTarget_).to.equal('_blank');
+      expect(port.args_).to.deep.equal({a: 1});
+      expect(port.options_).to.deep.equal({width: 300});
+    });
+
+    it('should open window with no args or options', () => {
+      activities.open(
+          'request1',
+          'https://example.com/file',
+          '_blank');
+      expect(openStub).to.be.calledOnce;
+      expect(acceptResultStub).to.be.calledOnce;
+      expect(port.args_).to.be.null;
+      expect(port.options_).to.be.null;
+    });
+
+    it('should yield onResult registered before or after popup', () => {
+      const onResultSpy = sandbox.spy();
+      activities.onResult('request1', onResultSpy);
+      activities.open(
+          'request1',
+          'https://example.com/file',
+          '_blank');
+      expect(onResultSpy).to.not.be.called;
+
+      // Yield result.
+      const result = new ActivityResult(ActivityResultCode.OK, 'success');
+      resultResolver(result);
+      return resultPromise.then(() => {
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        expect(onResultSpy).to.be.calledOnce;
+        expect(onResultSpy.args[0][0]).to.equal(port);
+
+        // Repeat, after popup.
+        activities.onResult('request1', onResultSpy);
+        expect(onResultSpy).to.be.calledOnce;
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        expect(onResultSpy).to.be.calledTwice;
+        expect(onResultSpy.args[1][0]).to.equal(port);
+      });
+    });
+
+    it('should support multiple onResult', () => {
+      const onResultSpy1 = sandbox.spy();
+      const onResultSpy2 = sandbox.spy();
+      const onResultSpy3 = sandbox.spy();
+      activities.onResult('request1', onResultSpy1);
+      activities.onResult('request1', onResultSpy2);
+      activities.open(
+          'request1',
+          'https://example.com/file',
+          '_blank');
+      expect(onResultSpy1).to.not.be.called;
+      expect(onResultSpy2).to.not.be.called;
+
+      // Yield result.
+      const result = new ActivityResult(ActivityResultCode.OK, 'success');
+      resultResolver(result);
+      return resultPromise.then(() => {
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        expect(onResultSpy1).to.be.calledOnce;
+        expect(onResultSpy1.args[0][0]).to.equal(port);
+        expect(onResultSpy2).to.be.calledOnce;
+        expect(onResultSpy2.args[0][0]).to.equal(port);
+
+        // Repeat, after popup.
+        activities.onResult('request1', onResultSpy3);
+        expect(onResultSpy3).to.not.be.called;
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        expect(onResultSpy1).to.be.calledOnce;
+        expect(onResultSpy2).to.be.calledOnce;
+        expect(onResultSpy3).to.be.calledOnce;
+        expect(onResultSpy3.args[0][0]).to.equal(port);
+      });
+    });
+
+    it('should tolerate callback failures', () => {
+      const onResultSpy1 = function() {
+        throw new Error('intentional');
+      };
+      const onResultSpy2 = sandbox.spy();
+      activities.onResult('request1', onResultSpy1);
+      activities.onResult('request1', onResultSpy2);
+      activities.open(
+          'request1',
+          'https://example.com/file',
+          '_blank');
+
+      // Yield result.
+      const result = new ActivityResult(ActivityResultCode.OK, 'success');
+      resultResolver(result);
+      return resultPromise.then(() => {
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        expect(onResultSpy2).to.be.calledOnce;
+        expect(onResultSpy2.args[0][0]).to.equal(port);
+      });
+    });
+
+    it('should pick up redirect result', () => {
+      win.location.hash = '#__WA_RES__=' + encodeURIComponent(
+          JSON.stringify({
+            requestId: 'request1',
+            code: 'ok',
+            data: 'ok',
+            origin: 'https://example.com',
+          }));
+      const activities = new Activities(win);
+
+      const onResultSpy1 = sandbox.spy();
+      const onResultSpy2 = sandbox.spy();
+      const onResultSpy3 = sandbox.spy();
+      const otherSpy = sandbox.spy();
+      activities.onResult('request1', onResultSpy1);
+      activities.onResult('request1', onResultSpy2);
+      activities.onResult('request2', otherSpy);
+      expect(onResultSpy1).to.not.be.called;
+      expect(onResultSpy2).to.not.be.called;
+
+      // Skip a microtask.
+      let port;
+      return Promise.resolve().then(() => {
+        expect(onResultSpy1).to.be.calledOnce;
+        port = onResultSpy1.args[0][0];
+        expect(port).to.exist;
+        expect(onResultSpy2).to.be.calledOnce;
+        expect(onResultSpy2.args[0][0]).to.equal(port);
+
+        // Repeat, after popup.
+        activities.onResult('request1', onResultSpy3);
+        expect(onResultSpy3).to.not.be.called;
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        expect(onResultSpy1).to.be.calledOnce;
+        expect(onResultSpy2).to.be.calledOnce;
+        expect(onResultSpy3).to.be.calledOnce;
+        expect(onResultSpy3.args[0][0]).to.equal(port);
+        expect(otherSpy).to.not.be.called;
+      });
+    });
+  });
+
   describe('connectHost', () => {
+    let initialHost;
     let connectPromise, connectResolve, connectReject;
+    let popupConnectStub;
 
     beforeEach(() => {
       connectPromise = new Promise((resolve, reject) => {
@@ -98,12 +291,29 @@ describes.realWin('Activities', {}, env => {
       sandbox.stub(
           ActivityIframeHost.prototype,
           'connect',
-          () => connectPromise);
+          function() {
+            initialHost = this;
+            return connectPromise;
+          });
+      popupConnectStub = sandbox.stub(
+          ActivityWindowPopupHost.prototype,
+          'connect',
+          function() {
+            initialHost = this;
+            return connectPromise;
+          });
+      sandbox.stub(
+          ActivityWindowRedirectHost.prototype,
+          'connect',
+          function() {
+            initialHost = this;
+            return connectPromise;
+          });
     });
 
     it('should connect the host', () => {
       const promise = activities.connectHost();
-      connectResolve();
+      connectResolve(initialHost);
       return promise.then(host => {
         expect(host).to.be.instanceof(ActivityIframeHost);
       });
@@ -113,6 +323,61 @@ describes.realWin('Activities', {}, env => {
       const promise = activities.connectHost();
       connectReject(new Error('intentional'));
       return expect(promise).to.eventually.be.rejectedWith('intentional');
+    });
+
+    describe('types of hosts', () => {
+      beforeEach(() => {
+        win = {
+          location: {},
+        };
+        win.top = win;
+        activities = new Activities(win);
+      });
+
+      it('should connect iframe host', () => {
+        win.top = {};  // Iframe: top != this.
+        const promise = activities.connectHost();
+        connectResolve(initialHost);
+        return promise.then(host => {
+          expect(host).to.be.instanceof(ActivityIframeHost);
+        });
+      });
+
+      it('should connect popup host', () => {
+        win.opener = {};  // Popup: opener exists.
+        const promise = activities.connectHost();
+        connectResolve(initialHost);
+        return promise.then(host => {
+          expect(host).to.be.instanceof(ActivityWindowPopupHost);
+        });
+      });
+
+      it('should connect redirect host', () => {
+        win.opener = null;  // Redirect: no opener.
+        const promise = activities.connectHost();
+        connectResolve(initialHost);
+        return promise.then(host => {
+          expect(host).to.be.instanceof(ActivityWindowRedirectHost);
+        });
+      });
+
+      it('should delegate to another host', () => {
+        const other = {};
+        win.opener = {};  // Popup: opener exists.
+        const promise = activities.connectHost();
+        connectResolve(other);
+        return promise.then(host => {
+          expect(host).to.equal(other);
+        });
+      });
+
+      it('should propagate request', () => {
+        const request = {};
+        win.opener = {};  // Popup: opener exists.
+        activities.connectHost(request);
+        expect(popupConnectStub).to.be.calledOnce;
+        expect(popupConnectStub).to.be.calledWith(request);
+      });
     });
   });
 });

--- a/test/functional/activities-test.js
+++ b/test/functional/activities-test.js
@@ -95,22 +95,18 @@ describes.realWin('Activities', {}, env => {
   describe('open/onResult', () => {
     let openStub;
     let port;
-    let resultPromise, resultResolver;
-    let acceptResultStub;
+    let openPromise, openResolver;
 
     beforeEach(() => {
       port = null;
+      openPromise = new Promise(resolve => {
+        openResolver = resolve;
+      });
       openStub = sandbox.stub(ActivityWindowPort.prototype, 'open',
           function() {
             port = this;
+            return openPromise;
           });
-      resultPromise = new Promise(resolve => {
-        resultResolver = resolve;
-      });
-      acceptResultStub = sandbox.stub(
-          ActivityWindowPort.prototype,
-          'acceptResult',
-          () => resultPromise);
     });
 
     it('should open window', () => {
@@ -121,7 +117,6 @@ describes.realWin('Activities', {}, env => {
           {a: 1},
           {width: 300});
       expect(openStub).to.be.calledOnce;
-      expect(acceptResultStub).to.be.calledOnce;
       expect(port).to.exist;
       expect(port).to.be.instanceof(ActivityWindowPort);
       expect(port.requestId_).to.equal('request1');
@@ -137,7 +132,6 @@ describes.realWin('Activities', {}, env => {
           'https://example.com/file',
           '_blank');
       expect(openStub).to.be.calledOnce;
-      expect(acceptResultStub).to.be.calledOnce;
       expect(port.args_).to.be.null;
       expect(port.options_).to.be.null;
     });
@@ -153,8 +147,8 @@ describes.realWin('Activities', {}, env => {
 
       // Yield result.
       const result = new ActivityResult(ActivityResultCode.OK, 'success');
-      resultResolver(result);
-      return resultPromise.then(() => {
+      openResolver(result);
+      return openPromise.then(() => {
         // Skip a microtask.
         return Promise.resolve();
       }).then(() => {
@@ -187,8 +181,8 @@ describes.realWin('Activities', {}, env => {
 
       // Yield result.
       const result = new ActivityResult(ActivityResultCode.OK, 'success');
-      resultResolver(result);
-      return resultPromise.then(() => {
+      openResolver(result);
+      return openPromise.then(() => {
         // Skip a microtask.
         return Promise.resolve();
       }).then(() => {
@@ -224,8 +218,8 @@ describes.realWin('Activities', {}, env => {
 
       // Yield result.
       const result = new ActivityResult(ActivityResultCode.OK, 'success');
-      resultResolver(result);
-      return resultPromise.then(() => {
+      openResolver(result);
+      return openPromise.then(() => {
         // Skip a microtask.
         return Promise.resolve();
       }).then(() => {

--- a/test/functional/activity-iframe-integr-test.js
+++ b/test/functional/activity-iframe-integr-test.js
@@ -26,20 +26,16 @@ describes.fixture('ActivityIframePort integration', {}, env => {
   beforeEach(() => {
     fixture = env.fixture;
     const fixtureUrl = env.fixtureUrl('activity-iframe-host', 'sp');
-    const a = document.createElement('a');
-    a.href = fixtureUrl;
-    const origin = a.origin || a.protocol + '//' + a.host;
     port = new ActivityIframePort(
         env.iframe,
         fixtureUrl,
-        origin,
         {a: 1});
     return Promise.all([fixture.connected(), port.connect()]);
   });
 
   it('should return "result"', () => {
     fixture.send('return-result', 'abc');
-    return port.awaitResult().then(result => {
+    return port.acceptResult().then(result => {
       expect(result.ok).to.be.true;
       expect(result.data).to.equal('abc');
     });
@@ -47,7 +43,7 @@ describes.fixture('ActivityIframePort integration', {}, env => {
 
   it('should return "canceled"', () => {
     fixture.send('return-canceled');
-    return port.awaitResult().then(result => {
+    return port.acceptResult().then(result => {
       expect(result.ok).to.be.false;
       expect(result.code).to.equal(ActivityResultCode.CANCELED);
     });
@@ -55,7 +51,7 @@ describes.fixture('ActivityIframePort integration', {}, env => {
 
   it('should return "failed"', () => {
     fixture.send('return-failed', 'broken');
-    return port.awaitResult().then(result => {
+    return port.acceptResult().then(result => {
       expect(result.ok).to.be.false;
       expect(result.code).to.equal(ActivityResultCode.FAILED);
       expect(result.error.message).to.match(/broken/);

--- a/test/functional/activity-window-host-test.js
+++ b/test/functional/activity-window-host-test.js
@@ -1,0 +1,590 @@
+/**
+ * @license
+ * Copyright 2017 The Web Activities Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActivityWindowPopupHost,
+  ActivityWindowRedirectHost,
+} from '../../src/activity-window-host';
+import {ActivityMode} from '../../src/activity-types';
+import {getWindowOrigin, serializeRequest} from '../../src/utils';
+
+
+describes.realWin('ActivityWindowPopupHost', {}, env => {
+  let win, doc;
+  let host;
+  let opener;
+  let messenger;
+  let closer, closeSpy;
+  let container;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    opener = {
+      postMessage: sandbox.spy(),
+    };
+    Object.defineProperty(win, 'opener', {value: opener});
+
+    host = new ActivityWindowPopupHost(win);
+    messenger = host.messenger_;
+
+    closer = () => {};
+    closeSpy = sandbox.stub(win, 'close', function() {
+      closer();
+    });
+
+    container = doc.createElement('div');
+    doc.body.appendChild(container);
+    host.setSizeContainer(container);
+  });
+
+  afterEach(() => {
+    messenger.disconnect();
+  });
+
+  it('should return mode', () => {
+    expect(host.getMode()).to.equal(ActivityMode.POPUP);
+  });
+
+  it('should fail before connected', () => {
+    expect(() => {
+      messenger.getTarget();
+    }).to.throw(/not connected/);
+    expect(() => {
+      messenger.getTargetOrigin();
+    }).to.throw(/not connected/);
+  });
+
+  it('should initialize messenger on connect', () => {
+    const sendCommandStub = sandbox.stub(messenger, 'sendCommand');
+    const redirectConnectPromise = Promise.resolve();
+    const redirectConnectStub =
+        sandbox.stub(host.redirectHost_, 'connect',
+            () => redirectConnectPromise);
+    host.connect('{}');
+    expect(redirectConnectStub).to.be.calledWith('{}');
+    return redirectConnectPromise.then(() => {
+      expect(messenger.getTarget()).to.equal(opener);
+      expect(() => {
+        messenger.getTargetOrigin();
+      }).to.throw(/not connected/);
+      expect(() => {
+        host.isTargetOriginVerified();
+      }).to.throw(/not connected/);
+      expect(() => {
+        host.getArgs();
+      }).to.throw(/not connected/);
+      expect(sendCommandStub).to.be.calledOnce;
+      expect(sendCommandStub).to.be.calledWith('connect');
+      expect(host.connected_).to.be.false;
+      expect(messenger.onCommand_).to.exist;
+
+      // Disconnect.
+      const disconnectStub = sandbox.stub(messenger, 'disconnect');
+      host.disconnect();
+      expect(disconnectStub).to.be.calledOnce;
+    });
+  });
+
+  it('should close window on disconnect', () => {
+    expect(closeSpy).to.not.be.called;
+    host.disconnect();
+    expect(closeSpy).to.be.calledOnce;
+  });
+
+  it('should tolerate close window failures on disconnect', () => {
+    closer = () => {
+      throw new Error('intentional');
+    };
+    host.disconnect();
+    expect(closeSpy).to.be.calledOnce;
+  });
+
+  it('should continue with popup host if connect arrives on time', () => {
+    sandbox.stub(messenger, 'sendCommand');
+    const request = {
+      requestId: 'request1',
+      returnUrl: 'https://example.com/opener',
+    };
+    const connectPromise = host.connect(request);
+    return Promise.resolve().then(() => {
+      // Skip microtask.
+      return Promise.resolve();
+    }).then(() => {
+      messenger.handleEvent_({
+        origin: 'https://example-pub.com',
+        data: {
+          sentinel: '__ACTIVITIES__',
+          cmd: 'start',
+        },
+      });
+      return connectPromise;
+    }).then(host => {
+      expect(host).to.be.instanceof(ActivityWindowPopupHost);
+    });
+  });
+
+  it('should fallback to redirect on connect timeout', () => {
+    const clock = sandbox.useFakeTimers();
+    sandbox.stub(messenger, 'sendCommand');
+    const request = {
+      requestId: 'request1',
+      returnUrl: 'https://example.com/opener',
+    };
+    const connectPromise = host.connect(request);
+    return Promise.resolve().then(() => {
+      // Skip microtask.
+      return Promise.resolve();
+    }).then(() => {
+      clock.tick(6000);
+      return connectPromise;
+    }).then(host => {
+      expect(host).to.be.instanceof(ActivityWindowRedirectHost);
+    });
+  });
+
+  it('should failed to return properties before connect', () => {
+    expect(() => host.getRequestString())
+        .to.throw(/not connected/);
+    expect(() => host.getTargetOrigin())
+        .to.throw(/not connected/);
+    expect(() => host.isTargetOriginVerified())
+        .to.throw(/not connected/);
+    expect(() => host.getArgs())
+        .to.throw(/not connected/);
+  });
+
+  it('should not accept before connection', () => {
+    expect(() => host.accept())
+        .to.throw(/not connected/);
+  });
+
+  describe('commands', () => {
+    let connectPromise;
+    let onEvent;
+    let sendCommandStub;
+    let clock;
+    let request;
+
+    beforeEach(() => {
+      clock = sandbox.useFakeTimers();
+      request = {
+        requestId: 'request1',
+        returnUrl: 'https://example-pub.com/opener',
+        args: {a: 1},
+      };
+      connectPromise = host.connect(request);
+      return Promise.resolve().then(() => {
+        // Skip a microtask.
+        return Promise.resolve();
+      }).then(() => {
+        onEvent = messenger.handleEvent_.bind(messenger);
+        sendCommandStub = sandbox.stub(messenger, 'sendCommand');
+        onCommand('start', {a: 1});
+      });
+    });
+
+    afterEach(() => {
+      host.disconnect();
+    });
+
+    function onCommand(cmd, payload) {
+      onEvent({
+        origin: 'https://example-pub.com',
+        data: {
+          sentinel: '__ACTIVITIES__',
+          cmd,
+          payload,
+        },
+      });
+    }
+
+    it('should return connect properties', () => {
+      expect(host.getTargetOrigin()).to.equal('https://example-pub.com');
+      expect(host.isTargetOriginVerified()).to.be.true;
+      expect(host.isSecureChannel()).to.be.true;
+      expect(host.getArgs()).to.deep.equal({a: 1});
+    });
+
+    it('should return the request', () => {
+      expect(host.getRequestString())
+          .to.be.equal(serializeRequest(request));
+    });
+
+    it('should handle "start" and "close"', () => {
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      return connectPromise.then(connectResult => {
+        expect(connectResult).to.equal(host);
+        expect(messenger.getTarget()).to.equal(opener);
+        expect(host.getTargetOrigin()).to.equal('https://example-pub.com');
+        expect(host.getArgs()).to.deep.equal({a: 1});
+        expect(host.connected_).to.be.true;
+
+        expect(disconnectStub).to.not.be.called;
+        onCommand('close');
+        expect(disconnectStub).to.be.calledOnce;
+      });
+    });
+
+    it('should not allow result/cancel/fail before accept', () => {
+      expect(() => host.result('abc'))
+          .to.throw(/not accepted/);
+      expect(() => host.cancel())
+          .to.throw(/not accepted/);
+      expect(() => host.failed(new Error('intentional')))
+          .to.throw(/not accepted/);
+    });
+
+    it('should yield "result"', () => {
+      host.accept();
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      host.result('abc');
+      expect(sendCommandStub).to.be.calledOnce;
+      expect(sendCommandStub).to.be.calledWith('result', {
+        code: 'ok',
+        data: 'abc',
+      });
+      // Do not disconnect, wait for "close" message to ack the result receipt.
+      expect(disconnectStub).to.not.be.called;
+    });
+
+    it('should yield "result" with null', () => {
+      host.accept();
+      host.result(null);
+      expect(sendCommandStub).to.be.calledOnce;
+      expect(sendCommandStub).to.be.calledWith('result', {
+        code: 'ok',
+        data: null,
+      });
+    });
+
+    it('should yield "canceled"', () => {
+      host.accept();
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      host.cancel();
+      expect(sendCommandStub).to.be.calledOnce;
+      expect(sendCommandStub).to.be.calledWith('result', {
+        code: 'canceled',
+        data: null,
+      });
+      expect(disconnectStub).to.not.be.called;
+    });
+
+    it('should yield "failed"', () => {
+      host.accept();
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      host.failed(new Error('broken'));
+      expect(sendCommandStub).to.be.calledOnce;
+      expect(sendCommandStub).to.be.calledWith('result', {
+        code: 'failed',
+        data: 'Error: broken',
+      });
+      expect(disconnectStub).to.not.be.called;
+    });
+
+    it('should not allow "ready" signal before accept', () => {
+      expect(() => host.ready())
+          .to.throw(/not accepted/);
+    });
+
+    it('should send "ready" signal', () => {
+      host.accept();
+
+      // Ready.
+      host.ready();
+      expect(sendCommandStub).to.be.calledOnce;
+      expect(sendCommandStub).to.be.calledWith('ready');
+
+      // Disconnect.
+      host.disconnect();
+    });
+
+    it('should handle "resized"', () => {
+      const callback = sandbox.spy();
+      host.onResizeComplete(callback);
+      expect(callback).to.not.be.called;
+
+      const availableHeight = win.innerHeight;
+      const requestedHeight = (availableHeight - 10);
+      container.style.height = requestedHeight + 'px';
+      host.resized();
+      clock.tick(100);
+      expect(callback).to.be.calledOnce;
+      expect(callback).to.be.calledWith(
+          /* allowedHeight */ availableHeight,
+          /* requestedHeight */ requestedHeight,
+          /* overfow */ false);
+    });
+
+    it('should handle "resized" with overflow', () => {
+      const callback = sandbox.spy();
+      host.onResizeComplete(callback);
+      expect(callback).to.not.be.called;
+
+      const availableHeight = win.innerHeight;
+      const requestedHeight = (availableHeight + 10);
+      container.style.height = requestedHeight + 'px';
+      host.resized();
+      clock.tick(100);
+      expect(callback).to.be.calledOnce;
+      expect(callback).to.be.calledWith(
+          /* allowedHeight */ availableHeight,
+          /* requestedHeight */ requestedHeight,
+          /* overfow */ true);
+    });
+  });
+});
+
+
+describes.realWin('ActivityWindowRedirectHost', {}, env => {
+  let win, doc;
+  let host;
+  let closeSpy;
+  let container;
+  let redirectStub;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    host = new ActivityWindowRedirectHost(win);
+    redirectStub = sandbox.stub(host, 'redirect_');
+    closeSpy = sandbox.stub(win, 'close');
+    container = doc.createElement('div');
+    doc.body.appendChild(container);
+    host.setSizeContainer(container);
+  });
+
+  afterEach(() => {
+    expect(closeSpy).to.not.be.called;
+  });
+
+  it('should return mode', () => {
+    expect(host.getMode()).to.equal(ActivityMode.REDIRECT);
+  });
+
+  it('should failed to return properties before connect', () => {
+    expect(() => host.getRequestString())
+        .to.throw(/not connected/);
+    expect(() => host.getTargetOrigin())
+        .to.throw(/not connected/);
+    expect(() => host.isTargetOriginVerified())
+        .to.throw(/not connected/);
+    expect(() => host.getArgs())
+        .to.throw(/not connected/);
+  });
+
+  it('should not accept before connection', () => {
+    expect(() => host.accept())
+        .to.throw(/not connected/);
+  });
+
+  it('should connect with request object', () => {
+    const request = {
+      requestId: 'request1',
+      returnUrl: 'https://example.com/opener',
+      args: {a: 1},
+    };
+    expect(() => {
+      host.getTargetOrigin();
+    }).to.throw(/not connected/);
+    expect(() => {
+      host.isTargetOriginVerified();
+    }).to.throw(/not connected/);
+    expect(() => {
+      host.getArgs();
+    }).to.throw(/not connected/);
+    expect(host.connected_).to.be.false;
+    return host.connect(request).then(result => {
+      expect(host.connected_).to.be.true;
+      expect(host.accepted_).to.be.false;
+      expect(result).to.equal(host);
+      expect(host.getTargetOrigin()).to.equal('https://example.com');
+      expect(host.isTargetOriginVerified()).to.be.false;
+      expect(host.isSecureChannel()).to.be.false;
+      expect(host.getArgs()).to.deep.equal({a: 1});
+      expect(host.getRequestString()).to.equal(serializeRequest(request));
+
+      // Disconnect.
+      host.accepted_ = true;
+      host.disconnect();
+      expect(host.connected_).to.be.false;
+      expect(host.accepted_).to.be.false;
+    });
+  });
+
+  it('should connect with request string', () => {
+    const request = {
+      requestId: 'request1',
+      returnUrl: 'https://example.com/opener',
+      args: {a: 1},
+    };
+    return host.connect(serializeRequest(request)).then(result => {
+      expect(result).to.equal(host);
+      expect(host.getTargetOrigin()).to.equal('https://example.com');
+      expect(host.isTargetOriginVerified()).to.be.false;
+      expect(host.isSecureChannel()).to.be.false;
+      expect(host.getRequestString()).to.equal(serializeRequest(request));
+    });
+  });
+
+  it('should connect with request fragment', () => {
+    const request = {
+      requestId: 'request1',
+      returnUrl: 'https://example.com/opener',
+      args: {a: 1},
+    };
+    win.location.hash = '#__WA__=' +
+        encodeURIComponent(serializeRequest(request));
+    return host.connect().then(result => {
+      expect(result).to.equal(host);
+      expect(host.getTargetOrigin()).to.equal('https://example.com');
+      expect(host.isTargetOriginVerified()).to.be.false;
+      expect(host.isSecureChannel()).to.be.false;
+      expect(host.getRequestString()).to.equal(serializeRequest(request));
+    });
+  });
+
+  describe('commands', () => {
+    let clock;
+    let request;
+
+    beforeEach(() => {
+      clock = sandbox.useFakeTimers();
+      request = {
+        requestId: 'request1',
+        returnUrl: 'https://example-pub.com/opener',
+        args: {a: 1},
+      };
+      return host.connect(request);
+    });
+
+    afterEach(() => {
+      host.disconnect();
+    });
+
+    function returnUrl(code, data) {
+      return 'https://example-pub.com/opener#__WA_RES__=' +
+          encodeURIComponent(JSON.stringify({
+            requestId: 'request1',
+            origin: getWindowOrigin(win),
+            code,
+            data,
+          }));
+    }
+
+    it('should return connect properties', () => {
+      expect(host.getTargetOrigin()).to.equal('https://example-pub.com');
+      expect(host.isTargetOriginVerified()).to.be.false;
+      expect(host.isSecureChannel()).to.be.false;
+      expect(host.getArgs()).to.deep.equal({a: 1});
+    });
+
+    it('should return the request', () => {
+      expect(host.getRequestString())
+          .to.be.equal(serializeRequest(request));
+    });
+
+    it('should not allow result/cancel/fail before accept', () => {
+      expect(() => host.result('abc'))
+          .to.throw(/not accepted/);
+      expect(() => host.cancel())
+          .to.throw(/not accepted/);
+      expect(() => host.failed(new Error('intentional')))
+          .to.throw(/not accepted/);
+    });
+
+    it('should yield "result"', () => {
+      host.accept();
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      host.result('abc');
+      expect(redirectStub).to.be.calledOnce;
+      expect(redirectStub).to.be.calledWith(returnUrl('ok', 'abc'));
+      // Do not disconnect, wait for "close" message to ack the result receipt.
+      expect(disconnectStub).to.not.be.called;
+    });
+
+    it('should yield "result" with null', () => {
+      host.accept();
+      host.result(null);
+      expect(redirectStub).to.be.calledOnce;
+      expect(redirectStub).to.be.calledWith(returnUrl('ok', null));
+    });
+
+    it('should yield "canceled"', () => {
+      host.accept();
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      host.cancel();
+      expect(redirectStub).to.be.calledOnce;
+      expect(redirectStub).to.be.calledWith(returnUrl('canceled', null));
+      expect(disconnectStub).to.not.be.called;
+    });
+
+    it('should yield "failed"', () => {
+      host.accept();
+      const disconnectStub = sandbox.stub(host, 'disconnect');
+      host.failed(new Error('broken'));
+      expect(redirectStub).to.be.calledOnce;
+      expect(redirectStub).to.be.calledWith(
+          returnUrl('failed', 'Error: broken'));
+      expect(disconnectStub).to.not.be.called;
+    });
+
+    it('should not allow "ready" signal before accept', () => {
+      expect(() => host.ready())
+          .to.throw(/not accepted/);
+    });
+
+    it('should ignore "ready" signal', () => {
+      host.accept();
+      host.ready();
+    });
+
+    it('should handle "resized"', () => {
+      const callback = sandbox.spy();
+      host.onResizeComplete(callback);
+      expect(callback).to.not.be.called;
+
+      const availableHeight = win.innerHeight;
+      const requestedHeight = (availableHeight - 10);
+      container.style.height = requestedHeight + 'px';
+      host.resized();
+      clock.tick(100);
+      expect(callback).to.be.calledOnce;
+      expect(callback).to.be.calledWith(
+          /* allowedHeight */ availableHeight,
+          /* requestedHeight */ requestedHeight,
+          /* overfow */ false);
+    });
+
+    it('should handle "resized" with overflow', () => {
+      const callback = sandbox.spy();
+      host.onResizeComplete(callback);
+      expect(callback).to.not.be.called;
+
+      const availableHeight = win.innerHeight;
+      const requestedHeight = (availableHeight + 10);
+      container.style.height = requestedHeight + 'px';
+      host.resized();
+      clock.tick(100);
+      expect(callback).to.be.calledOnce;
+      expect(callback).to.be.calledWith(
+          /* allowedHeight */ availableHeight,
+          /* requestedHeight */ requestedHeight,
+          /* overfow */ true);
+    });
+  });
+});

--- a/test/functional/activity-window-port-test.js
+++ b/test/functional/activity-window-port-test.js
@@ -1,0 +1,562 @@
+/**
+ * @license
+ * Copyright 2017 The Web Activities Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActivityWindowPort,
+  discoverRedirectPort,
+} from '../../src/activity-window-port';
+import {ActivityMode, ActivityResultCode} from '../../src/activity-types';
+import {
+  getQueryParam,
+  parseRequest,
+} from '../../src/utils';
+
+
+describes.realWin('ActivityWindowPort', {}, env => {
+  let win;
+
+  beforeEach(() => {
+    win = env.win;
+  });
+
+  it('should validate the target', () => {
+    const request = 'request1';
+    const url = 'https://example-sp.com/popup';
+    expect(() => {
+      new ActivityWindowPort(win, request, url, null);
+    }).to.throw(/allowed targets/);
+    expect(() => {
+      new ActivityWindowPort(win, request, url, '');
+    }).to.throw(/allowed targets/);
+    expect(() => {
+      new ActivityWindowPort(win, request, url, '_self');
+    }).to.throw(/allowed targets/);
+    expect(() => {
+      new ActivityWindowPort(win, request, url, '_parent');
+    }).to.throw(/allowed targets/);
+
+    // Allowed targets.
+    new ActivityWindowPort(win, request, url, '_blank');
+    new ActivityWindowPort(win, request, url, '_top');
+    new ActivityWindowPort(win, request, url, 'other');
+  });
+
+  describe('popup', () => {
+    let port;
+    let windowOpenStub;
+    let openFunc;
+    let popup;
+
+    beforeEach(() => {
+      popup = {};
+      openFunc = () => popup;
+      windowOpenStub = sandbox.stub(win, 'open',
+          function(url, target, features) {
+            return openFunc(url, target, features);
+          });
+      port = new ActivityWindowPort(
+          win,
+          'request1',
+          'https://example-sp.com/popup',
+          '_blank',
+          {a: 1});
+    });
+
+    it('should initialize mode', () => {
+      expect(port.getMode()).to.equal(ActivityMode.POPUP);
+    });
+
+    it('should consider named target a popup as well', () => {
+      port = new ActivityWindowPort(
+          win,
+          'request1',
+          'https://example-sp.com/popup',
+          'popup1');
+      expect(port.getMode()).to.equal(ActivityMode.POPUP);
+    });
+
+    describe('features and options', () => {
+
+      function getFeatures(options) {
+        port = new ActivityWindowPort(
+            win,
+            'request1',
+            'https://example-sp.com/popup',
+            '_blank',
+            {a: 1},
+            options);
+        port.open();
+        const featuresStr = windowOpenStub.args[0][2];
+        return featuresStr.split(',');
+      }
+
+      function getUrl(options, opt_url) {
+        port = new ActivityWindowPort(
+            win,
+            'request1',
+            opt_url || 'https://example-sp.com/popup',
+            '_blank',
+            {a: 1},
+            options);
+        port.open();
+        return windowOpenStub.args[windowOpenStub.callCount - 1][0];
+      }
+
+      function getRequest(options, opt_url) {
+        const url = getUrl(options, opt_url);
+        const frag = url.substring(url.indexOf('#'));
+        return parseRequest(getQueryParam(frag, '__WA__'));
+      }
+
+      it('should always include resizable and scrollbars', () => {
+        const features = getFeatures();
+        expect(features).to.contain('resizable=yes');
+        expect(features).to.contain('scrollbars=yes');
+      });
+
+      it('should build features with big screen', () => {
+        win.screen = {width: 2000, height: 1000};
+        const features = getFeatures();
+        expect(features).to.contain('width=600');
+        expect(features).to.contain('height=600');
+        expect(features).to.contain('left=700');  // (2000 - 600) / 2
+        expect(features).to.contain('top=200');  // (1000 - 600) / 2
+      });
+
+      it('should build features with small screen', () => {
+        win.screen = {width: 300, height: 500};
+        const features = getFeatures();
+        expect(features).to.contain('width=270');  // 300 * 0.9
+        expect(features).to.contain('height=450');  // 500 * 0.9
+        expect(features).to.contain('left=15');  // (300 - 270) / 2
+        expect(features).to.contain('top=25');  // (500 - 450) / 2
+      });
+
+      it('should override width and height', () => {
+        win.screen = {width: 2000, height: 1000};
+        const features = getFeatures({width: 100, height: 200});
+        expect(features).to.contain('width=100');
+        expect(features).to.contain('height=200');
+        expect(features).to.contain('left=950');  // (2000 - 100) / 2
+        expect(features).to.contain('top=400');  // (1000 - 200) / 2
+      });
+
+      it('should override width and height, but min at screen', () => {
+        win.screen = {width: 300, height: 500};
+        const features = getFeatures({width: 1000, height: 2000});
+        expect(features).to.contain('width=300');  // 300 * 0.9
+        expect(features).to.contain('height=500');  // 500 * 0.9
+        expect(features).to.contain('left=0');
+        expect(features).to.contain('top=0');
+      });
+
+      it('should default return url', () => {
+        win.location.hash = '#aaa';
+        const request = getRequest();
+        expect(request.requestId).to.equal('request1');
+        expect(request.returnUrl).to.equal('about:srcdoc');
+        expect(request.args).to.deep.equal({a: 1});
+      });
+
+      it('should default return url with empty options', () => {
+        const request = getRequest({});
+        expect(request.returnUrl).to.equal('about:srcdoc');
+      });
+
+      it('should override return url', () => {
+        const request = getRequest({
+          returnUrl: 'https://example.com/other',
+        });
+        expect(request.returnUrl).to.equal('https://example.com/other');
+      });
+
+      it('should add fragment correctly', () => {
+        expect(getUrl({}, 'https://example-sp.com/popup'))
+            .to.contain('https://example-sp.com/popup#__WA__=%7');
+        expect(getUrl({}, 'https://example-sp.com/popup#'))
+            .to.contain('https://example-sp.com/popup#&__WA__=%7');
+        expect(getUrl({}, 'https://example-sp.com/popup#abc'))
+            .to.contain('https://example-sp.com/popup#abc&__WA__=%7');
+      });
+    });
+
+    describe('open', () => {
+
+      it('should open with the right target', () => {
+        port.open();
+        expect(windowOpenStub).to.be.calledOnce;
+        expect(windowOpenStub.args[0][1]).to.equal('_blank');
+        expect(port.targetWin_).to.equal(popup);
+      });
+
+      it('should fallback to redirect if returns null', () => {
+        openFunc = (url, target) => {
+          if (target == '_blank') {
+            return null;
+          }
+          return popup;
+        };
+        port.open();
+        expect(windowOpenStub).to.be.calledTwice;
+        expect(windowOpenStub.args[0][1]).to.equal('_blank');
+        expect(windowOpenStub.args[1][1]).to.equal('_top');
+        expect(port.targetWin_).to.equal(popup);
+      });
+
+      it('should fallback to redirect if fails', () => {
+        openFunc = (url, target) => {
+          if (target == '_blank') {
+            throw new Error('intentional');
+          }
+          return popup;
+        };
+        port.open();
+        expect(windowOpenStub).to.be.calledTwice;
+        expect(windowOpenStub.args[0][1]).to.equal('_blank');
+        expect(windowOpenStub.args[1][1]).to.equal('_top');
+        expect(port.targetWin_).to.equal(popup);
+      });
+
+      it('should reject if all fallbacks fail', () => {
+        openFunc = () => {
+          throw new Error('intentional');
+        };
+        port.open();
+        expect(windowOpenStub).to.be.calledTwice;
+        expect(windowOpenStub.args[0][1]).to.equal('_blank');
+        expect(windowOpenStub.args[1][1]).to.equal('_top');
+        expect(port.targetWin_).to.be.null;
+        return expect(port.acceptResult()).to.be.eventually
+            .rejectedWith(/failed to open window/);
+      });
+
+      it('should not fallback to redirect for _top', () => {
+        port = new ActivityWindowPort(
+            win,
+            'request1',
+            'https://example-sp.com/popup',
+            '_top');
+        openFunc = () => {
+          throw new Error('intentional');
+        };
+        port.open();
+        expect(windowOpenStub).to.be.calledOnce;
+        expect(windowOpenStub.args[0][1]).to.equal('_top');
+        expect(port.targetWin_).to.be.null;
+        return expect(port.acceptResult()).to.be.eventually
+            .rejectedWith(/failed to open window/);
+      });
+    });
+
+    describe('popup opened', () => {
+      let messenger;
+      let heartbeatFunc;
+      let timeoutCallbacks;
+
+      beforeEach(() => {
+        heartbeatFunc = null;
+        win.setInterval = function(callback) {
+          heartbeatFunc = callback;
+          return 1;
+        };
+        win.clearInterval = function(id) {
+          if (id == 1) {
+            heartbeatFunc = null;
+          }
+        };
+        timeoutCallbacks = [];
+        win.setTimeout = function(callback) {
+          timeoutCallbacks.push(callback);
+        };
+        port.open();
+        messenger = port.messenger_;
+      });
+
+      afterEach(() => {
+        messenger.disconnect();
+      });
+
+      function flushTimeouts() {
+        timeoutCallbacks.forEach(callback => {
+          callback();
+        });
+        timeoutCallbacks.length = 0;
+      }
+
+      it('should create messenger', () => {
+        expect(messenger).to.exist;
+        expect(messenger.onCommand_).to.exist;
+      });
+
+      it('should not create messenger for redirect', () => {
+        port = new ActivityWindowPort(
+            win,
+            'request1',
+            'https://example-sp.com/popup',
+            '_top');
+        port.open();
+        expect(port.messenger_).to.be.null;
+      });
+
+      it('should disconnect messenger', () => {
+        messenger.onCommand_ = function() {};
+        port.disconnect();
+        expect(messenger.onCommand_).to.be.null;
+        expect(port.messenger_).to.be.null;
+      });
+
+      it('should close popup on disconnect', () => {
+        popup.close = sandbox.spy();
+        port.disconnect();
+        expect(popup.close).to.be.calledOnce;
+        expect(port.targetWin_).to.be.null;
+      });
+
+      it('should tolerate close popup failures on disconnect', () => {
+        popup.close = function() {
+          throw new Error('intentional');
+        };
+        port.disconnect();
+        expect(port.targetWin_).to.be.null;
+      });
+
+      it('should not allow target origin until connected', () => {
+        expect(() => port.getTargetOrigin())
+            .to.throw(/not connected/);
+      });
+
+      it('should set up heartbeat', () => {
+        expect(heartbeatFunc).to.exist;
+        expect(port.heartbeatInterval_).to.equal(1);
+        port.disconnect();
+        expect(heartbeatFunc).to.be.null;
+        expect(port.heartbeatInterval_).to.be.null;
+      });
+
+      it('should execute heartbeat when window is open/closed', () => {
+        expect(heartbeatFunc).to.exist;
+        heartbeatFunc();
+        flushTimeouts();
+        expect(heartbeatFunc).to.exist;
+        expect(port.heartbeatInterval_).to.exist;
+        expect(port.resultReject_).to.exist;
+
+        popup.closed = true;
+        heartbeatFunc();
+        expect(heartbeatFunc).to.be.null;
+        expect(port.heartbeatInterval_).to.be.null;
+        expect(port.resultReject_).to.exist;
+
+        // Timeout is important to give activity a chance to message data back.
+        flushTimeouts();
+        expect(heartbeatFunc).to.be.null;
+        expect(port.heartbeatInterval_).to.be.null;
+        expect(port.resultReject_).to.be.null;
+        return expect(port.acceptResult()).to.be.eventually.rejected;
+      });
+
+      describe('connected', () => {
+        let onCommand;
+        let sendCommandStub;
+
+        beforeEach(() => {
+          onCommand = messenger.onCommand_;
+          sendCommandStub = sandbox.stub(messenger, 'sendCommand');
+          messenger.handleEvent_({
+            origin: 'https://example-sp.com',
+            source: popup,
+            data: {
+              sentinel: '__ACTIVITIES__',
+              cmd: 'connect',
+            },
+          });
+        });
+
+        afterEach(() => {
+          port.disconnect();
+        });
+
+        it('should resolve target properties', () => {
+          expect(port.getTargetOrigin()).to.equal('https://example-sp.com');
+          expect(port.isTargetOriginVerified()).to.be.true;
+          expect(port.isSecureChannel()).to.be.true;
+        });
+
+        it('should execute heartbeat when window is open/closed', () => {
+          expect(heartbeatFunc).to.exist;
+          heartbeatFunc();
+          flushTimeouts();
+          expect(heartbeatFunc).to.exist;
+          expect(port.heartbeatInterval_).to.exist;
+          expect(port.resultReject_).to.exist;
+
+          popup.closed = true;
+          heartbeatFunc();
+          expect(heartbeatFunc).to.be.null;
+          expect(port.heartbeatInterval_).to.be.null;
+          expect(port.resultReject_).to.exist;
+
+          // Timeout is important to give activity a chance to message data back.
+          flushTimeouts();
+          expect(heartbeatFunc).to.be.null;
+          expect(port.heartbeatInterval_).to.be.null;
+          expect(port.resultReject_).to.be.null;
+          return port.acceptResult().then(result => {
+            expect(result.code).to.equal(ActivityResultCode.CANCELED);
+          });
+        });
+
+        it('should handle "connect"', () => {
+          expect(sendCommandStub).to.be.calledOnce;
+          expect(sendCommandStub).to.be.calledWith('start', {a: 1});
+        });
+
+        it('should handle successful "result"', () => {
+          expect(sendCommandStub).to.not.be.calledWith('close');
+          onCommand('result', {code: 'ok', data: 'success'});
+          expect(sendCommandStub).to.be.calledWith('close');
+          return port.acceptResult().then(result => {
+            expect(result.ok).to.be.true;
+            expect(result.code).to.equal(ActivityResultCode.OK);
+            expect(result.data).to.equal('success');
+            expect(result.origin).to.equal('https://example-sp.com');
+            expect(result.originVerified).to.be.true;
+            expect(result.secureChannel).to.be.true;
+            expect(heartbeatFunc).to.be.null;
+          });
+        });
+
+        it('should handle cancel "result"', () => {
+          onCommand('result', {code: 'canceled', data: null});
+          expect(sendCommandStub).to.be.calledWith('close');
+          return port.acceptResult().then(result => {
+            expect(result.ok).to.be.false;
+            expect(result.code).to.equal(ActivityResultCode.CANCELED);
+            expect(result.data).to.be.null;
+            expect(result.origin).to.equal('https://example-sp.com');
+            expect(result.originVerified).to.be.true;
+            expect(result.secureChannel).to.be.true;
+            expect(heartbeatFunc).to.be.null;
+          });
+        });
+
+        it('should handle failed "result"', () => {
+          onCommand('result', {code: 'failed', data: 'broken'});
+          expect(sendCommandStub).to.be.calledWith('close');
+          return port.acceptResult().then(result => {
+            expect(result.ok).to.be.false;
+            expect(result.code).to.equal(ActivityResultCode.FAILED);
+            expect(result.error).to.be.instanceof(Error);
+            expect(result.error.message).to.match(/broken/);
+            expect(result.data).to.be.null;
+            expect(result.origin).to.equal('https://example-sp.com');
+            expect(result.originVerified).to.be.true;
+            expect(result.secureChannel).to.be.true;
+            expect(heartbeatFunc).to.be.null;
+          });
+        });
+
+        it('should ignore noop events', () => {
+          sendCommandStub.reset();
+          onCommand('ready');
+          onCommand('resize', {height: 111});
+          expect(sendCommandStub).to.not.be.called;
+        });
+      });
+    });
+
+  });
+
+  describe('discoverRedirectPort', () => {
+    let replaceStateSpy;
+    let historyState;
+
+    beforeEach(() => {
+      if (win.history) {
+        historyState = win.history.state;
+        replaceStateSpy = sandbox.stub(win.history, 'replaceState');
+      } else {
+        replaceStateSpy = sandbox.spy();
+        historyState = 'S';
+        win.history = {state: historyState, replaceState: replaceStateSpy};
+      }
+    });
+
+    function discover(response, requestId, opt_setFragment) {
+      const fragment = '#__WA_RES__=' +
+          encodeURIComponent(JSON.stringify(response));
+      if (opt_setFragment) {
+        win.location.hash = fragment;
+      }
+      return discoverRedirectPort(win, fragment, requestId);
+    }
+
+    it('should discover the response', () => {
+      const port = discover({
+        requestId: 'request1',
+        code: 'ok',
+        data: {a: 1},
+        origin: 'https://example-sp.com',
+      }, 'request1');
+      expect(port).to.exist;
+      expect(port.getMode()).to.equal(ActivityMode.REDIRECT);
+      expect(port.getTargetOrigin()).to.equal('https://example-sp.com');
+      expect(port.isTargetOriginVerified()).to.be.false;
+      expect(port.isSecureChannel()).to.be.false;
+      return port.acceptResult().then(result => {
+        expect(result.ok).to.be.true;
+        expect(result.code).to.equal(ActivityResultCode.OK);
+        expect(result.data).to.deep.equal({a: 1});
+        expect(result.origin).to.equal('https://example-sp.com');
+        expect(result.originVerified).to.be.false;
+        expect(result.secureChannel).to.be.false;
+        expect(replaceStateSpy).to.not.be.called;
+      });
+    });
+
+    it('should ignore empty/null fragment', () => {
+      expect(discoverRedirectPort(win, null, 'request1')).to.be.null;
+      expect(discoverRedirectPort(win, '', 'request1')).to.be.null;
+      expect(discoverRedirectPort(win, '#', 'request1')).to.be.null;
+      expect(discoverRedirectPort(win, '#__WA_RES__=', 'request1')).to.be.null;
+    });
+
+    it('should remove fragment for the matched response', () => {
+      const port = discover({
+        requestId: 'request1',
+        code: 'ok',
+        data: {a: 1},
+        origin: 'https://example-sp.com',
+      }, 'request1', true);
+      expect(port).to.exist;
+      expect(replaceStateSpy).to.be.calledOnce;
+      expect(replaceStateSpy.args[0][0]).to.equal(historyState);
+      expect(replaceStateSpy.args[0][2]).to.equal('#');
+    });
+
+    it('should ignore another response', () => {
+      const port = discover({
+        requestId: 'request1',
+        code: 'ok',
+        data: {a: 1},
+        origin: 'https://example-sp.com',
+      }, 'request2', true);
+      expect(port).to.be.null;
+      expect(replaceStateSpy).to.not.be.called;
+    });
+  });
+});

--- a/test/functional/messenger-test.js
+++ b/test/functional/messenger-test.js
@@ -191,6 +191,16 @@ describes.realWin('Messenger', {}, env => {
       expect(onCommand.args[0][1]).to.deep.equal({a: 1});
     });
 
+    it('should initialize origin when source matches', () => {
+      const handler = addEventListenerSpy.args[0][1];
+      handler({
+        origin: 'https://example-sp.com',
+        data: {sentinel: '__ACTIVITIES__', cmd: 'other', payload: {a: 1}},
+        source: target,  // This is the important part where target matches.
+      });
+      expect(messenger.getTargetOrigin()).to.equal('https://example-sp.com');
+    });
+
     it('should disallow origin initialization w/o connect', () => {
       const handler = addEventListenerSpy.args[0][1];
       handler({

--- a/test/functional/utils-test.js
+++ b/test/functional/utils-test.js
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2017 The Web Activities Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as utils from '../../src/utils';
+
+
+describe('utils', () => {
+
+  describe('getOriginFromUrl', () => {
+    it('should return origin for absolute URL', () => {
+      expect(utils.getOriginFromUrl('https://example.com'))
+          .to.equal('https://example.com');
+      expect(utils.getOriginFromUrl('https://example.com/'))
+          .to.equal('https://example.com');
+      expect(utils.getOriginFromUrl('https://example.com/file'))
+          .to.equal('https://example.com');
+      expect(utils.getOriginFromUrl('https://example.com:111/file'))
+          .to.equal('https://example.com:111');
+    });
+
+    it('should return origin for a relative URL', () => {
+      expect(utils.getOriginFromUrl('/file'))
+          .to.equal(window.location.protocol + '//' + window.location.host);
+    });
+
+    it('should return canonical origin', () => {
+      expect(utils.getOriginFromUrl('https://example.com:443/'))
+          .to.equal('https://example.com');
+      expect(utils.getOriginFromUrl('http://example.com:80/'))
+          .to.equal('http://example.com');
+      expect(utils.getOriginFromUrl('https://eXaMplE.COM/'))
+          .to.equal('https://example.com');
+    });
+  });
+
+  describe('getWindowOrigin', () => {
+    it('should return window origin', () => {
+      expect(utils.getWindowOrigin(window))
+          .to.equal(window.location.protocol + '//' + window.location.host);
+    });
+
+    it('should return window origin for a modern window', () => {
+      const modernWindow = {
+        origin: 'https://example.com',
+      };
+      expect(utils.getWindowOrigin(modernWindow))
+          .to.equal('https://example.com');
+    });
+
+    it('should return window origin for a legacy win, but modern loc', () => {
+      const legacyWin = {
+        location: {
+          origin: 'https://example.com',
+        },
+      };
+      expect(utils.getWindowOrigin(legacyWin))
+          .to.equal('https://example.com');
+    });
+
+    it('should return window origin for a legacy window and location', () => {
+      const legacyWin = {
+        location: {
+          protocol: 'https:',
+          host: 'example.com',
+        },
+      };
+      expect(utils.getWindowOrigin(legacyWin))
+          .to.equal('https://example.com');
+    });
+  });
+
+  describe('removeFragment', () => {
+    it('should remove fragment with empty URL', () => {
+      expect(utils.removeFragment('')).to.equal('');
+    });
+
+    it('should remove fragment with absolute URL', () => {
+      expect(utils.removeFragment('https://a.com/file?query#fragment'))
+          .to.equal('https://a.com/file?query');
+    });
+
+    it('should remove fragment with relative URL', () => {
+      expect(utils.removeFragment('/file?query#fragment'))
+          .to.equal('/file?query');
+    });
+
+    it('should remove an empty fragment', () => {
+      expect(utils.removeFragment('/file?query#'))
+          .to.equal('/file?query');
+    });
+  });
+
+  describe('getQueryParam', () => {
+    const QUERY = 'a=one&_a=one&b=t%3do&c%20d=three&f=four&f=five&g=&h=';
+
+    it('should resolve query param', () => {
+      expect(utils.getQueryParam(QUERY, 'a')).to.equal('one');
+      expect(utils.getQueryParam('?' + QUERY, 'a')).to.equal('one');
+      expect(utils.getQueryParam('#' + QUERY, 'a')).to.equal('one');
+    });
+
+    it('should resolve encoded value', () => {
+      expect(utils.getQueryParam(QUERY, 'b')).to.equal('t=o');
+    });
+
+    it('should resolve encoded name', () => {
+      expect(utils.getQueryParam(QUERY, 'c d')).to.equal('three');
+    });
+
+    it('should resolve last value', () => {
+      expect(utils.getQueryParam(QUERY, 'f')).to.equal('five');
+    });
+
+    it('should resolve unknown value', () => {
+      expect(utils.getQueryParam(QUERY, 'x')).to.be.undefined;
+    });
+
+    it('should resolve empty value', () => {
+      expect(utils.getQueryParam(QUERY, 'g')).to.equal('');
+      expect(utils.getQueryParam(QUERY, 'h')).to.equal('');
+    });
+  });
+
+  describe('removeQueryParam', () => {
+    const QUERY = 'a=one&_z=zed&b=t%3do&c%20d=three&f=four&f=five&g=&h=';
+
+    it('should remove query param', () => {
+      expect(utils.removeQueryParam(QUERY, 'a'))
+          .to.equal(QUERY.replace('a=one&', ''));
+      expect(utils.removeQueryParam('?' + QUERY, 'a'))
+          .to.equal('?' + QUERY.replace('a=one&', ''));
+      expect(utils.removeQueryParam('#' + QUERY, 'a'))
+          .to.equal('#' + QUERY.replace('a=one&', ''));
+    });
+
+    it('should remove encoded name', () => {
+      expect(utils.removeQueryParam(QUERY, 'c d'))
+          .to.equal(QUERY.replace('c%20d=three&', ''));
+    });
+
+    it('should remove all value', () => {
+      expect(utils.removeQueryParam(QUERY, 'f'))
+          .to.equal(QUERY
+              .replace('f=four&', '')
+              .replace('f=five&', ''));
+    });
+
+    it('should ignore unknown value', () => {
+      expect(utils.removeQueryParam(QUERY, 'x')).to.equal(QUERY);
+    });
+
+    it('should ignore false matches', () => {
+      expect(utils.removeQueryParam(QUERY, 'z')).to.equal(QUERY);
+    });
+
+    it('should remove empty values', () => {
+      expect(utils.removeQueryParam(QUERY, 'g'))
+          .to.equal(QUERY.replace('g=&', ''));
+      expect(utils.removeQueryParam(QUERY, 'h'))
+          .to.equal(QUERY.replace('h=', ''));
+    });
+  });
+
+  describe('parseRequest/serializeRequest', () => {
+    it('should parse request', () => {
+      const request = {
+        requestId: 'request1',
+        returnUrl: 'https://example.com/back',
+        args: {a: 1},
+      };
+      expect(utils.parseRequest(utils.serializeRequest(request)))
+          .to.deep.equal(request);
+    });
+
+    it('should parse request with no args', () => {
+      const request = {
+        requestId: 'request1',
+        returnUrl: 'https://example.com/back',
+        args: null,
+      };
+      expect(utils.parseRequest(utils.serializeRequest(request)))
+          .to.deep.equal(request);
+    });
+
+    it('should tolerate request with no requestId and returnUrl', () => {
+      const request = {
+        requestId: null,
+        returnUrl: null,
+        args: null,
+      };
+      expect(utils.parseRequest(utils.serializeRequest(request)))
+          .to.deep.equal(request);
+    });
+
+    it('should not parse null/empty string', () => {
+      expect(utils.parseRequest(null)).to.be.null;
+      expect(utils.parseRequest('')).to.be.null;
+    });
+  });
+});

--- a/test/manual/client.html
+++ b/test/manual/client.html
@@ -28,13 +28,37 @@
   <h1>Activity Client</h1>
 
   <button onclick="startIframe()">start iframe</button>
+  <button onclick="startPopup()">start popup</button>
+  <button onclick="startRedirect()">start redirect</button>
 
+  <p></p>
+  <hr>
+  Result:
+  <pre id="result_element"></pre>
 <script>
   function whenReady(callback) {
     (window.ACTIVITIES = window.ACTIVITIES || []).push(function(activities) {
       callback(activities);
     });
   }
+
+  function printResult(result) {
+    console.log('CLIENT: result = ', result);
+    document.getElementById('result_element').textContent =
+        JSON.stringify(result, true, 2);
+  }
+
+  function printError(reason) {
+    console.log('CLIENT: failed: ', reason);
+    document.getElementById('result_element').textContent =
+        'ERROR: ' + reason;
+  }
+
+  whenReady(function(activities) {
+    activities.onResult('request1', function(port) {
+      port.acceptResult().then(printResult);
+    });
+  });
 
   function startIframe() {
     whenReady(function(activities) {
@@ -56,8 +80,7 @@
         doc.body.appendChild(iframe);
         return activities.openIframe(
             iframe,
-            'http://sp.localhost:8000/test/manual/host-iframe.html',
-            'http://sp.localhost:8000',
+            'http://sp.localhost:8000/test/manual/host.html',
             {
               publicationId: 'scenic',
             });
@@ -68,19 +91,41 @@
           container.style.height = allowed + 'px';
           port.resized();
         });
-        return port.awaitResult();
-      }).then(function(result) {
-        console.log('CLIENT: result = ', result);
-      }, function(reason) {
-        console.log('CLIENT: failed: ', reason);
-      }).then(function() {
+        return port.acceptResult();
+      }).then(printResult, printError).then(function() {
         container.parentNode.removeChild(container);
       });
       document.body.appendChild(container);
     });
   }
 
-  startIframe();
+  function startPopup() {
+    whenReady(function(activities) {
+      return activities.open(
+          'request1',
+          'http://sp.localhost:8000/test/manual/host.html',
+          'popup111',
+          {
+            publicationId: 'scenic',
+          }, {
+            width: 300,
+          });
+    });
+  }
+
+  function startRedirect() {
+    whenReady(function(activities) {
+      return activities.open(
+          'request1',
+          'http://sp.localhost:8000/test/manual/host.html',
+          '_top',
+          {
+            publicationId: 'scenic',
+          }, {
+            width: 300,
+          });
+    });
+  }
 </script>
 </body>
 </html>

--- a/test/manual/host.html
+++ b/test/manual/host.html
@@ -53,9 +53,13 @@
       var origin = host.getTargetOrigin();
       var args = host.getArgs();
       if (args.publicationId != 'scenic' || origin != 'http://localhost:8000') {
+        console.log('Host arg failure:',
+            'wrong pubid or origin: ' + args.publicationId + '/' + origin);
         host.failed(new Error('wrong pubid or origin: ' + args.publicationId + '/' + origin));
         throw new Error('failed checks!');
       }
+      console.log('Accept: ', origin, host.isTargetOriginVerified(), args);
+      host.accept();
     }).then(function() {
       host.setSizeContainer(container);
       host.onResizeComplete(function(height, requestedHeight, overflow) {
@@ -72,6 +76,7 @@
       };
       host.ready();
     }).catch(function(reason) {
+      console.log('Host error: ', reason);
       if (host) {
         host.failed(reason);
       }


### PR DESCRIPTION
The popup/redirect are handled by the same API and distinction is mostly managed automatically. It looks like this:

```
// Should always be called in anticipation of redirect.
activities.onResult('request1', function(port) {
  // Check if activity origin/channel are acceptable.
  // The check depends on the actual activity. In some cases,
  // the payload is not sensitive and origin/verified/secure flags are
  // not relevant. In other cases, origin/verified/secure are very
  // strict. Yet, in some other case, origin is important, but the payload
  // itself can be independently verified and thus verified/secure
  // do not matter.
  if (port.getTargetOrigin() != expectedOrigin ||
      !port.isTargetOriginVerified() ||
      !port.isSecureChannel()) {
    return;
  }
  port.acceptResult().then(function(result) {
    // Handle the result.
  });
});

// Start the activity.
activities.open('request1', 'https://a.com/activity', '_blank', {args: 1});
```
