### PR TITLE
API shift to reject promise on cancel and fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To open the activity as a standalone page (popup or redirect):
 // First setup callback, even if you are not yet starting an activity. This
 // will ensure that you are always prepared to handle redirect results.
 ports.onResult(resultId, port => {
-  // Check origin properties.
   port.acceptResult().then(result => {
+    // Check origin properties.
     // Handle the result.
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "web-activities",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Web Activities",
   "main": "./activities.js",
   "engines": {

--- a/src/activity-ports.js
+++ b/src/activity-ports.js
@@ -119,14 +119,14 @@ export class ActivityPorts {
    * A typical implementation would look like:
    * ```
    * ports.onResult('request1', function(port) {
-   *   // Only verified origins are allowed.
-   *   if (port.getTargetOrigin() == expectedOrigin &&
-   *       port.isTargetOriginVerified() &&
-   *       port.isSecureChannel()) {
-   *     port.acceptResult().then(function(result) {
+   *   port.acceptResult().then(function(result) {
+   *     // Only verified origins are allowed.
+   *     if (result.origin == expectedOrigin &&
+   *         result.originVerified &&
+   *         result.secureChannel) {
    *       handleResultForRequest1(result);
-   *     });
-   *   }
+   *     }
+   *   });
    * })
    *
    * ports.open('request1', request1Url, '_blank');

--- a/src/activity-types.js
+++ b/src/activity-types.js
@@ -17,6 +17,16 @@
 
 
 /**
+ * @enum {string}
+ */
+export const ActivityMode = {
+  IFRAME: 'iframe',
+  POPUP: 'popup',
+  REDIRECT: 'redirect',
+};
+
+
+/**
  * The result code used for `ActivityResult`.
  * @enum {string}
  */
@@ -36,15 +46,18 @@ export class ActivityResult {
   /**
    * @param {!ActivityResultCode} code
    * @param {*} data
+   * @param {!ActivityMode} mode
    * @param {string} origin
    * @param {boolean} originVerified
    * @param {boolean} secureChannel
    */
-  constructor(code, data, origin, originVerified, secureChannel) {
+  constructor(code, data, mode, origin, originVerified, secureChannel) {
     /** @const {!ActivityResultCode} */
     this.code = code;
     /** @const {*} */
     this.data = code == ActivityResultCode.OK ? data : null;
+    /** @const {!ActivityMode} */
+    this.mode = mode;
     /** @const {string} */
     this.origin = origin;
     /** @const {boolean} */
@@ -95,16 +108,6 @@ export let ActivityOpenOptionsDef;
 
 
 /**
- * @enum {string}
- */
-export const ActivityMode = {
-  IFRAME: 'iframe',
-  POPUP: 'popup',
-  REDIRECT: 'redirect',
-};
-
-
-/**
  * Activity client-side binding. The port provides limited ways to communicate
  * with the activity and receive signals and results from it. Not every type
  * of activity exposes a port.
@@ -118,30 +121,6 @@ export class ActivityPortDef {
    * @return {!ActivityMode}
    */
   getMode() {}
-
-  /**
-   * The client's origin. The connection to the client must first succeed
-   * before the origin can be known with certainty.
-   * @return {string}
-   */
-  getTargetOrigin() {}
-
-  /**
-   * Whether the client's origin has been verified. This depends on the type of
-   * the client connection. When window messaging is used (for iframes and
-   * popups), the origin can be verified. In case of redirects, where state is
-   * passed in the URL, the verification is not fully possible.
-   * @return {boolean}
-   */
-  isTargetOriginVerified() {}
-
-  /**
-   * Whether the client/host communication is done via a secure channel such
-   * as messaging, or an open and easily exploitable channel, such redirect URL.
-   * Iframes and popups use a secure channel, and the redirect mode does not.
-   * @return {boolean}
-   */
-  isSecureChannel() {}
 
   /**
    * Accepts the result when ready. The client should verify the activity's

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,6 +207,8 @@ export function serializeRequest(request) {
 
 
 /**
+ * Creates or emulates a DOMException of AbortError type.
+ * See https://heycam.github.io/webidl/#aborterror.
  * @param {!Window} win
  * @param {string=} opt_message
  * @return {!DOMException}
@@ -232,6 +234,11 @@ export function createAbortError(win, opt_message) {
 
 
 /**
+ * Resolves the activity result as a promise:
+ *  - `OK` result is yielded as the promise's payload;
+ *  - `CANCEL` result is rejected with the `AbortError`;
+ *  - `FAILED` result is rejected with the embedded error.
+ *
  * @param {!Window} win
  * @param {!./activity-types.ActivityResult} result
  * @param {function((!./activity-types.ActivityResult|!Promise))} resolver

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,12 @@
 
 import {ActivityRequestDef} from './activity-types';
 
+/** DOMException.ABORT_ERR name */
+const ABORT_ERR_NAME = 'AbortError';
+
+/** DOMException.ABORT_ERR = 20 */
+const ABORT_ERR_CODE = 20;
+
 /** @type {?HTMLAnchorElement} */
 let aResolver;
 
@@ -197,4 +203,45 @@ export function serializeRequest(request) {
     map['originVerified'] = request.originVerified;
   }
   return JSON.stringify(map);
+}
+
+
+/**
+ * @param {!Window} win
+ * @param {string=} opt_message
+ * @return {!DOMException}
+ */
+export function createAbortError(win, opt_message) {
+  const message = 'AbortError' + (opt_message ? ': ' + opt_message : '');
+  let error;
+  if ('DOMException' in win) {
+    // TODO(dvoytenko): remove typecast once externs are fixed.
+    const constr = /** @type {function(new:DOMException, string, string)} */ (
+        DOMException);
+    error = new constr(message, ABORT_ERR_NAME);
+  } else {
+    // TODO(dvoytenko): remove typecast once externs are fixed.
+    const constr = /** @type {function(new:DOMException, string)} */ (
+        Error);
+    error = new constr(message);
+    error.name = ABORT_ERR_NAME;
+    error.code = ABORT_ERR_CODE;
+  }
+  return error;
+}
+
+
+/**
+ * @param {!Window} win
+ * @param {!./activity-types.ActivityResult} result
+ * @param {function((!./activity-types.ActivityResult|!Promise))} resolver
+ */
+export function resolveResult(win, result, resolver) {
+  if (result.ok) {
+    resolver(result);
+  } else {
+    const error = result.error || createAbortError(win);
+    error.activityResult = result;
+    resolver(Promise.reject(error));
+  }
 }

--- a/test/functional/activity-iframe-integr-test.js
+++ b/test/functional/activity-iframe-integr-test.js
@@ -43,7 +43,13 @@ describes.fixture('ActivityIframePort integration', {}, env => {
 
   it('should return "canceled"', () => {
     fixture.send('return-canceled');
-    return port.acceptResult().then(result => {
+    return port.acceptResult().then(() => {
+      throw new Error('must have failed');
+    }, reason => {
+      expect(reason).to.be.instanceof(DOMException);
+      expect(reason.code).to.equal(20);
+      expect(reason.name).to.equal('AbortError');
+      const result = reason.activityResult;
       expect(result.ok).to.be.false;
       expect(result.code).to.equal(ActivityResultCode.CANCELED);
     });
@@ -51,7 +57,11 @@ describes.fixture('ActivityIframePort integration', {}, env => {
 
   it('should return "failed"', () => {
     fixture.send('return-failed', 'broken');
-    return port.acceptResult().then(result => {
+    return port.acceptResult().then(() => {
+      throw new Error('must have failed');
+    }, reason => {
+      expect(() => {throw reason;}).to.throw(/broken/);
+      const result = reason.activityResult;
       expect(result.ok).to.be.false;
       expect(result.code).to.equal(ActivityResultCode.FAILED);
       expect(result.error.message).to.match(/broken/);


### PR DESCRIPTION
Breaking API changes for 1.0.0. The cancelation and error are now rejecting promise. This is consistent with newer Web APIs, such as PaymentRequest.