### PR TITLE
Speed cancel signal when detected on the host side

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "web-activities",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Web Activities",
   "main": "./activities.js",
   "engines": {

--- a/test/functional/activity-window-port-test.js
+++ b/test/functional/activity-window-port-test.js
@@ -297,10 +297,11 @@ describes.realWin('ActivityWindowPort', {}, env => {
       });
 
       function flushTimeouts() {
-        timeoutCallbacks.forEach(callback => {
+        const callbacks = timeoutCallbacks.slice(0);
+        timeoutCallbacks.length = 0;
+        callbacks.forEach(callback => {
           callback();
         });
-        timeoutCallbacks.length = 0;
       }
 
       it('should create messenger', () => {
@@ -440,6 +441,21 @@ describes.realWin('ActivityWindowPort', {}, env => {
             expect(result.secureChannel).to.be.true;
             expect(result.originVerified).to.be.true;
             expect(result.origin).to.equal('https://example-sp.com');
+          });
+        });
+
+        it('should check if window still exists on unload message', () => {
+          flushTimeouts();
+          popup.closed = true;
+          onCommand('check', {});
+          flushTimeouts();
+          return Promise.resolve().then(() => {
+            flushTimeouts();
+            return port.acceptResult();
+          }).then(() => {
+            throw new Error('must have failed');
+          }, reason => {
+            expect(reason.name).to.equal('AbortError');
           });
         });
 


### PR DESCRIPTION
Host closing is equivalent to "cancel" signal. This is how it works: when the host is unloading, it tries to send the message the client to check whether the window is closed. The fact of unloading itself is not a guarantee that the host is indeed closed, it could be refreshed or redirected to a new page, etc. So, the client simply checks to see if the window itself is closed and if it's the case, it'd immediately issue "cancel" signal. In most of browsers, this "check-if-canceled" signal is delivered even if the page is being unloaded; Chrome actually guarantees delivery of this message.

The net result: cancel signal is delivered within 100ms or so, comparing to the current median 1.5s.
