### PR TITLE
Workaround IE cross-origin popup problem

### DIFF
--- a/src/activity-window-port.js
+++ b/src/activity-window-port.js
@@ -173,11 +173,20 @@ export class ActivityWindowPort {
     }
 
     // Open the window.
+    let targetWin;
+    let openTarget = this.openTarget_;
+    // IE does not support CORS popups - the popup has to fallback to redirect
+    // mode.
+    if (openTarget != '_top') {
+      // MSIE and Trident are typical user agents for IE browsers.
+      const nav = this.win_.navigator;
+      if (/Trident|MSIE|IEMobile/i.test(nav && nav.userAgent)) {
+        openTarget = '_top';
+      }
+    }
     // Try first with the specified target. If we're inside the WKWebView or
     // a similar environments, this method is expected to fail by default for
     // all targets except `_top`.
-    let targetWin;
-    let openTarget = this.openTarget_;
     try {
       targetWin = this.win_.open(url, openTarget, featuresStr);
     } catch (e) {

--- a/test/functional/activity-window-port-test.js
+++ b/test/functional/activity-window-port-test.js
@@ -286,6 +286,17 @@ describes.realWin('ActivityWindowPort', {}, env => {
         return expect(port.acceptResult()).to.be.eventually
             .rejectedWith(/failed to open window/);
       });
+
+      it('should fallback to redirect on IE', () => {
+        Object.defineProperty(win.navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 7.0;' +
+              ' InfoPath.3; .NET CLR 3.1.40767; Trident/6.0; en-IN)',
+        });
+        port.open();
+        expect(windowOpenStub).to.be.calledOnce;
+        expect(windowOpenStub.args[0][1]).to.equal('_top');
+        expect(port.getTargetWin()).to.equal(popup);
+      });
     });
 
     describe('popup opened', () => {


### PR DESCRIPTION
An alternative to #37. The full solution to IE popup problem is not fully possible and not fully secure. Thus, instead, this change instead disables popup on IE and instead falls back to redirect.