### PR TITLE
Clients: require source match to differentiate between different iframes of the same origin

### DIFF
--- a/src/activity-iframe-host.js
+++ b/src/activity-iframe-host.js
@@ -46,7 +46,8 @@ export class ActivityIframeHost {
     this.messenger_ = new Messenger(
         this.win_,
         this.target_,
-        /* targetOrigin */ null);
+        /* targetOrigin */ null,
+        /* requireTarget */ false);
 
     /** @private {?Object} */
     this.args_ = null;

--- a/src/activity-iframe-port.js
+++ b/src/activity-iframe-port.js
@@ -90,7 +90,8 @@ export class ActivityIframePort {
     this.messenger_ = new Messenger(
         this.win_,
         () => this.iframe_.contentWindow,
-        this.targetOrigin_);
+        this.targetOrigin_,
+        /* requireTarget */ true);
   }
 
   /** @override */

--- a/src/activity-window-host.js
+++ b/src/activity-window-host.js
@@ -59,7 +59,8 @@ export class ActivityWindowPopupHost {
     this.messenger_ = new Messenger(
         this.win_,
         this.target_,
-        /* targetOrigin */ null);
+        /* targetOrigin */ null,
+        /* requireTarget */ false);
 
     /** @private {?Object} */
     this.args_ = null;

--- a/src/activity-window-port.js
+++ b/src/activity-window-port.js
@@ -305,7 +305,8 @@ export class ActivityWindowPort {
     this.messenger_ = new Messenger(
         this.win_,
         /** @type {!Window} */ (this.targetWin_),
-        /* targetOrigin */ null);
+        /* targetOrigin */ null,
+        /* requireTarget */ true);
     this.messenger_.connect(this.handleCommand_.bind(this));
   }
 

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -39,10 +39,12 @@ export class Messenger {
    * @param {!Window} win
    * @param {!Window|function():?Window} targetOrCallback
    * @param {?string} targetOrigin
+   * @param {boolean} requireTarget
    */
-  constructor(win, targetOrCallback, targetOrigin) {
+  constructor(win, targetOrCallback, targetOrigin, requireTarget) {
     /** @private @const {!Window} */
     this.win_ = win;
+
     /** @private @const {!Window|function():?Window} */
     this.targetOrCallback_ = targetOrCallback;
 
@@ -51,6 +53,9 @@ export class Messenger {
      * @private {?string}
      */
     this.targetOrigin_ = targetOrigin;
+
+    /** @private @const {boolean} */
+    this.requireTarget_ = requireTarget;
 
     /** @private {?Window} */
     this.target_ = null;
@@ -341,6 +346,13 @@ export class Messenger {
    * @private
    */
   handleEvent_(event) {
+    if (this.requireTarget_ && this.getOptionalTarget_() != event.source) {
+      // When target is required, confirm it against the event.source. This
+      // is normally only needed for ports where a single window can include
+      // multiple iframes to match the event to a specific iframe. Otherwise,
+      // the origin checks below are sufficient.
+      return;
+    }
     const data = event.data;
     if (!data || data['sentinel'] != SENTINEL) {
       return;

--- a/test/functional/activity-iframe-host-test.js
+++ b/test/functional/activity-iframe-host-test.js
@@ -53,6 +53,7 @@ describes.realWin('ActivityIframeHost', {}, env => {
   });
 
   it('should initialize messenger on connect', () => {
+    expect(messenger.requireTarget_).to.be.false;
     const sendCommandStub = sandbox.stub(messenger, 'sendCommand');
     host.connect();
     expect(messenger.getTarget()).to.equal(win.parent);

--- a/test/functional/activity-iframe-port-test.js
+++ b/test/functional/activity-iframe-port-test.js
@@ -58,6 +58,7 @@ describes.realWin('ActivityIframePort', {}, env => {
     expect(promise.then).to.be.a.function;
     expect(iframe.src).to.equal('https://example-sp.com/iframe');
     expect(messenger.onCommand_).to.be.a.function;
+    expect(messenger.requireTarget_).to.be.true;
   });
 
   it('should disconnect messenger', () => {

--- a/test/functional/activity-window-host-test.js
+++ b/test/functional/activity-window-host-test.js
@@ -92,6 +92,7 @@ describes.realWin('ActivityWindowPopupHost', {}, env => {
   });
 
   it('should initialize messenger on connect', () => {
+    expect(messenger.requireTarget_).to.be.false;
     const sendCommandStub = sandbox.stub(messenger, 'sendCommand');
     const redirectConnectPromise = Promise.resolve();
     const redirectConnectStub =
@@ -100,6 +101,7 @@ describes.realWin('ActivityWindowPopupHost', {}, env => {
     host.connect('{}');
     expect(redirectConnectStub).to.be.calledWith('{}');
     return redirectConnectPromise.then(() => {
+      expect(messenger.requireTarget_).to.be.false;
       expect(messenger.getTarget()).to.equal(opener);
       expect(() => {
         messenger.getTargetOrigin();

--- a/test/functional/activity-window-port-test.js
+++ b/test/functional/activity-window-port-test.js
@@ -500,6 +500,7 @@ describes.realWin('ActivityWindowPort', {}, env => {
       it('should create messenger', () => {
         expect(messenger).to.exist;
         expect(messenger.onCommand_).to.exist;
+        expect(messenger.requireTarget_).to.be.true;
       });
 
       it('should not create messenger for redirect', () => {


### PR DESCRIPTION
The current origin check is necessary, but not sufficient. This PR also adds `event.source` check on the client side to disambiguate between two iframes with the same origin. With popups such a case is a lot less likely, but for posterity the same check is added for that mode as well.